### PR TITLE
Implemented ox2 order-based crossover

### DIFF
--- a/src/recombinations.jl
+++ b/src/recombinations.jl
@@ -204,8 +204,29 @@ function cx{T <: Vector}(v1::T, v2::T)
 end
 
 # Order-based crossover
-function ox2{T <: Vector}(v1::T, v2::T)
-    # TODO
+function ox2{T <: Integer}(v1::Vector{T}, v2::Vector{T})
+  s = length(v1)
+  c1 = zeros(v1)
+  c2 = zeros(v2)
+
+  for i in 1:s
+    if rand(Bool)
+      c1[i] = v2[i]
+      c2[i] = v1[i]
+    end
+  end
+
+  for i in 1:s
+    if !in(v2[i],c1)
+      tmpin = inmap(zero(T),c1,1,s)
+      c1[tmpin] = v2[i]
+    end
+    if !in(v1[i],c2)
+      tmpin = inmap(zero(T),c2,1,s)
+      c2[tmpin] = v1[i]
+    end
+  end
+  return c1,c2
 end
 
 # Position-based crossover


### PR DESCRIPTION
Order based crossover.  The position of included parent elements is random, therefore ~50% of the parent order is maintained.  A more robust version could include a rate for inclusion.  

The method implemented is taken from this review: [http://www.sc.ehu.es/ccwbayes/docencia/kzmm/files/AG-TSP-operadoreak.pdf](url)
This implementation skips identifying random elements that are then indexed in the other parent to identify the fill points and instead directly identifies the fill points.  The outcome is identical.