### PR TITLE
Permcrosses

### DIFF
--- a/src/Evolutionary.jl
+++ b/src/Evolutionary.jl
@@ -12,7 +12,7 @@ module Evolutionary
            # GA recombinations
            singlepoint, twopoint, uniform,
            discrete, waverage, intermediate, line,
-           pmx, ox1, cx, ox2, pos
+           pmx, ox1, cx, ox2, pos,
            # GA selections
            ranklinear, uniformranking, roulette, sus, tournament, #truncation
            # Optimization methods

--- a/src/Evolutionary.jl
+++ b/src/Evolutionary.jl
@@ -12,7 +12,7 @@ module Evolutionary
            # GA recombinations
            singlepoint, twopoint, uniform,
            discrete, waverage, intermediate, line,
-           pmx, #ox1, cx, ox2, pos
+           pmx, ox1, cx, ox2, pos
            # GA selections
            ranklinear, uniformranking, roulette, sus, tournament, #truncation
            # Optimization methods

--- a/src/recombinations.jl
+++ b/src/recombinations.jl
@@ -206,17 +206,19 @@ function cx{T <: Integer}(v1::Vector{T}, v2::Vector{T})
   c1 = zeros(v1)
   c2 = zeros(v2)
 
-  f1 = true
+  f1 = true #switch
   k = 1
   while k > 0
     idx = k
     if f1
+      #cycle from v1
       while c1[idx] == zero(T)
         c1[idx] = v1[idx]
         c2[idx] = v2[idx]
         idx = inmap(v2[idx],v1,1,s)
       end
     else
+      #cycle from v2
       while c2[idx] == zero(T)
         c1[idx] = v2[idx]
         c2[idx] = v1[idx]

--- a/src/recombinations.jl
+++ b/src/recombinations.jl
@@ -248,8 +248,7 @@ function ox2{T <: Integer}(v1::Vector{T}, v2::Vector{T})
   c2 = copy(v2)
 
   for i in 1:s
-    # if rand(Bool)
-    if in(i,[2,3,6])
+    if rand(Bool)
       idx1 = inmap(v2[i],v1,1,s)
       idx2 = inmap(v1[i],v2,1,s)
       c1[idx1] = zero(T)
@@ -314,10 +313,3 @@ function inmap{T}(v::T, c::Vector{T}, from::Int, to::Int)
     end
     return exists
 end
-
-
-a = collect(1:8)
-b = [2,4,6,8,7,5,3,1]
-
-x = pos(a,b)
-

--- a/src/recombinations.jl
+++ b/src/recombinations.jl
@@ -268,8 +268,29 @@ function ox2{T <: Integer}(v1::Vector{T}, v2::Vector{T})
 end
 
 # Position-based crossover
-function pos{T <: Vector}(v1::T, v2::T)
-    # TODO
+function pos{T <: Integer}(v1::Vector{T}, v2::Vector{T})
+  s = length(v1)
+  c1 = zeros(v1)
+  c2 = zeros(v2)
+
+  for i in 1:s
+    if rand(Bool)
+      c1[i] = v2[i]
+      c2[i] = v1[i]
+    end
+  end
+
+  for i in 1:s
+    if !in(v1[i],c1)
+      tmpin = inmap(zero(T),c1,1,s)
+      c1[tmpin] = v1[i]
+    end
+    if !in(v2[i],c2)
+      tmpin = inmap(zero(T),c2,1,s)
+      c2[tmpin] = v2[i]
+    end
+  end
+  return c1,c2
 end
 
 

--- a/src/recombinations.jl
+++ b/src/recombinations.jl
@@ -195,45 +195,36 @@ function ox1{T <: Vector}(v1::T, v2::T)
     c1[from:to] = v2[from:to]
     c2[from:to] = v1[from:to]
     # Fill in from parents
+    for i in vcat()
+
     return c1, c2
 end
 
 # Cycle crossover
-function cx{T <: Vector}(v1::T, v2::T)
+function cx{T <: Integer}(v1::Vector{T}, v2::Vector{T})
   s = length(v1)
-  c1 = similar(v1)
-  c2 = similar(v2)
-  f1 = true
+  c1 = zeros(v1)
+  c2 = zeros(v2)
 
-  for i in 1:s
-    #Establish priority of parents
-    d1,d2 = f1 ? (v1,v2) : (v2,v1)
-    #Check existence in child1
-    in1 = inmap(d1[i],c1,1,s)
-    if in1 == 0
-      #fill
-      c1[i] = d1[i]
-      tmpin = inmap(c1[i],d2,1,s)
-      #cycle
-      while !in(d1[tmpin],c1)
-        c1[tmpin] = d1[tmpin]
-        tmpin = inmap(c1[tmpin],d2,1,s)
+  f1 = true
+  k = 1
+  while k > 0
+    idx = k
+    if f1
+      while c1[idx] == zero(T)
+        c1[idx] = v1[idx]
+        c2[idx] = v2[idx]
+        idx = inmap(v2[idx],v1,1,s)
       end
-      #reverse priority
-      f1 = false
-    end
-    #Check existence in child2
-    in2 = inmap(d2[i],c2,1,s)
-    if in2 == 0
-      #fill
-      c2[i] = d2[i]
-      tmpin = inmap(c2[i],d1,1,s)
-      #cycle
-      while !in(d2[tmpin],c2)
-        c2[tmpin] = d2[tmpin]
-        tmpin = inmap(c2[tmpin],d1,1,s)
+    else
+      while c2[idx] == zero(T)
+        c1[idx] = v2[idx]
+        c2[idx] = v1[idx]
+        idx = inmap(v1[idx],v2,1,s)
       end
     end
+    f1 $= true
+    k = inmap(zero(T),c2,1,s)
   end
   return c1,c2
 end

--- a/src/recombinations.jl
+++ b/src/recombinations.jl
@@ -244,13 +244,16 @@ end
 # Order-based crossover
 function ox2{T <: Integer}(v1::Vector{T}, v2::Vector{T})
   s = length(v1)
-  c1 = zeros(v1)
-  c2 = zeros(v2)
+  c1 = copy(v1)
+  c2 = copy(v2)
 
   for i in 1:s
-    if rand(Bool)
-      c1[i] = v2[i]
-      c2[i] = v1[i]
+    # if rand(Bool)
+    if in(i,[2,3,6])
+      idx1 = inmap(v2[i],v1,1,s)
+      idx2 = inmap(v1[i],v2,1,s)
+      c1[idx1] = zero(T)
+      c2[idx2] = zero(T)
     end
   end
 
@@ -311,3 +314,10 @@ function inmap{T}(v::T, c::Vector{T}, from::Int, to::Int)
     end
     return exists
 end
+
+
+a = collect(1:8)
+b = [2,4,6,8,7,5,3,1]
+
+x = pos(a,b)
+

--- a/src/recombinations.jl
+++ b/src/recombinations.jl
@@ -195,8 +195,6 @@ function ox1{T <: Vector}(v1::T, v2::T)
     c1[from:to] = v2[from:to]
     c2[from:to] = v1[from:to]
     # Fill in from parents
-    for i in vcat()
-
     return c1, c2
 end
 

--- a/src/recombinations.jl
+++ b/src/recombinations.jl
@@ -200,7 +200,42 @@ end
 
 # Cycle crossover
 function cx{T <: Vector}(v1::T, v2::T)
-    # TODO
+  s = length(v1)
+  c1 = similar(v1)
+  c2 = similar(v2)
+  f1 = true
+
+  for i in 1:s
+    #Establish priority of parents
+    d1,d2 = f1 ? (v1,v2) : (v2,v1)
+    #Check existence in child1
+    in1 = inmap(d1[i],c1,1,s)
+    if in1 == 0
+      #fill
+      c1[i] = d1[i]
+      tmpin = inmap(c1[i],d2,1,s)
+      #cycle
+      while !in(d1[tmpin],c1)
+        c1[tmpin] = d1[tmpin]
+        tmpin = inmap(c1[tmpin],d2,1,s)
+      end
+      #reverse priority
+      f1 = false
+    end
+    #Check existence in child2
+    in2 = inmap(d2[i],c2,1,s)
+    if in2 == 0
+      #fill
+      c2[i] = d2[i]
+      tmpin = inmap(c2[i],d1,1,s)
+      #cycle
+      while !in(d2[tmpin],c2)
+        c2[tmpin] = d2[tmpin]
+        tmpin = inmap(c2[tmpin],d1,1,s)
+      end
+    end
+  end
+  return c1,c2
 end
 
 # Order-based crossover


### PR DESCRIPTION
@wildart This includes all the missing permutation recombination operators.  If desired, i can rebase and implement all of these individually.  If this is accepted, #9 and #10 can be ignored.  Also, these rely on permutation vectors being true permutation vectors (Integers), perhaps all permutation operators should be written in the same way?  Tests can then be written that test whether ``` isperm() == true ```