### PR TITLE
Fix generation of contenders in case of duplicates

### DIFF
--- a/src/selections.jl
+++ b/src/selections.jl
@@ -72,7 +72,7 @@ function tournament(groupSize :: Int)
         for i in 1:N
             contender = unique(rand(1:nFitness, groupSize))
             while length(contender) < groupSize
-                contender = unique([contender, rand(1:nFitness, groupSize - length(contender))])
+                contender = unique(vcat(contender, rand(1:nFitness, groupSize - length(contender))))
             end
 
             winner = first(contender)


### PR DESCRIPTION
In the previous version, the algorithm created a list of lists instead
of a single list containing all contenders. The previous list is now
merged with the newly generated list using vcat().