### PR TITLE
Respect lower and upper bounds when generating population (fixes #15)

### DIFF
--- a/src/ga.jl
+++ b/src/ga.jl
@@ -45,7 +45,12 @@ function ga(objfun::Function, N::Int;
     # Generate population
     for i in 1:populationSize
         if isa(initPopulation, Vector)
-            population[i] = initPopulation.*rand(eltype(initPopulation), N)
+            if lowerBounds != nothing && upperBounds != nothing
+                population[i] = rand.(map(range, lowerBounds, upperBounds .- lowerBounds .+ 1))
+            else
+                # FIXME: why multiply?
+                population[i] = initPopulation.*rand(eltype(initPopulation), N)
+            end
         elseif isa(initPopulation, Matrix)
             population[i] = initPopulation[:, i]
         elseif isa(initPopulation, Function)


### PR DESCRIPTION
This is an attempt to fix #15 but I am not sure if it is robust to different input values. I tested it for integer values and it seemed to work fine. I'm open to suggestions for improvement, or to changing it entirely.

The FIXME comment is there because I did not understand the purpose of multiplying the random values with the `initPopulation`. Is there any benefit, given that the random values change it to something random anyway? I.e., what is the difference between `x*random` and pure `random`?