### PR TITLE
Separated out functionalities from initPopulation

### DIFF
--- a/src/Evolutionary.jl
+++ b/src/Evolutionary.jl
@@ -17,7 +17,6 @@ using Random
            es, cmaes, ga
 
     const Strategy = Dict{Symbol,Any}
-    const Individual = Union{Vector, Matrix, Function, Nothing}
 
     # Wrapping function for strategy
     function strategy(; kwargs...)
@@ -37,20 +36,14 @@ using Random
     end
 
     # Obtain individual
-    function getIndividual(init::Individual, N::Int)
-        if isa(init, Vector)
-            @assert length(init) == N "Dimensionality of initial population must be $(N)"
-            individual = init
-        elseif isa(init, Matrix)
-            @assert size(init, 1) == N "Dimensionality of initial population must be $(N)"
-            populationSize = size(init, 2)
-            individual = init[:, 1]
-        elseif isa(init, Function) # Creation function
-            individual = init(N)
+    function getIndividual(init::Union{Nothing, Vector}, creation::Function, N::Int)
+        if !isnothing(init)
+            individual = init[1]
+            @assert length(individual) == N "Dimensionality of initial population must be $(N)"
         else
-            individual = ones(N)
+            individual = creation(N)
         end
-        return  individual
+        return individual
     end
 
     # Collecting interim values

--- a/src/cmaes.jl
+++ b/src/cmaes.jl
@@ -9,8 +9,9 @@
 using LinearAlgebra
 using Statistics
 function cmaes( objfun::Function, N::Int;
-                initPopulation::Individual = ones(N),
+                initPopulation::Union{Nothing, Vector} = nothing,
                 initStrategy::Strategy = strategy(τ = sqrt(N), τ_c = N^2, τ_σ = sqrt(N)),
+                creation::Function = (n -> rand(n)),
                 μ::Integer = 1,
                 λ::Integer = 1,
                 iterations::Integer = 1_000,
@@ -20,7 +21,7 @@ function cmaes( objfun::Function, N::Int;
     @assert μ < λ "Offspring population must be larger then parent population"
 
     # Initialize parent population
-    individual = getIndividual(initPopulation, N)
+    individual = getIndividual(initPopulation, creation, N)
     population = fill(individual, μ)
     offspring = Array{typeof(individual)}(undef, λ)
     fitpop = fill(Inf, μ)

--- a/src/es.jl
+++ b/src/es.jl
@@ -11,13 +11,14 @@
 # Plus-selection: parents are deterministically selected from the set of both the parents and offspring
 #
 function es(  objfun::Function, N::Int;
-              initPopulation::Individual = ones(N),
+              initPopulation::Union{Nothing, Vector} = nothing,
               initStrategy::Strategy = strategy(),
-              recombination::Function = (rs->rs[1]),
-              srecombination::Function = (ss->ss[1]),
-              mutation::Function = ((r,m)->r),
-              smutation::Function = (s->s),
-              termination::Function = (x->false),
+              creation::Function = (n -> rand(n)),
+              recombination::Function = (rs -> rs[1]),
+              srecombination::Function = (ss -> ss[1]),
+              mutation::Function = ((r, m) -> r),
+              smutation::Function = (s -> s),
+              termination::Function = (x -> false),
               μ::Integer = 1,
               ρ::Integer = μ,
               λ::Integer = 1,
@@ -34,16 +35,14 @@ function es(  objfun::Function, N::Int;
     store = Dict{Symbol,Any}()
 
     # Initialize parent population
-    individual = getIndividual(initPopulation, N)
+    individual = getIndividual(initPopulation, creation, N)
     population = fill(individual, μ)
     fitness = zeros(μ)
     for i in 1:μ
-        if isa(initPopulation, Vector)
-            population[i] = initPopulation.*rand(N)
-        elseif isa(initPopulation, Matrix)
-            population[i] = initPopulation[:, i]
-        else # Creation function
-            population[i] = initPopulation(N)
+        if !isnothing(initPopulation)
+            population[i] = initPopulation[i]
+        else
+            population[i] = creation(N)
         end
         fitness[i] = objfun(population[i])
         debug && println("INIT $(i): $(population[i]) : $(fitness[i])")

--- a/test/knapsack.jl
+++ b/test/knapsack.jl
@@ -7,12 +7,12 @@
         return (total_mass <= 20) ? sum(utility .* n) : 0
     end
 
-    initpop = collect(rand(Bool,length(mass)))
+    creation = n -> rand(Bool, n)
 
     best, invbestfit, generations, tolerance, history = ga(
         x -> 1 / fitness(x),                    # Function to MINIMISE
-        length(initpop),                        # Length of chromosome
-        initPopulation = initpop,
+        length(mass),                           # Length of chromosome
+        creation = creation,
         selection = roulette,                   # Options: sus
         mutation = inversion,                   # Options:
         crossover = singlepoint,                # Options:

--- a/test/n-queens.jl
+++ b/test/n-queens.jl
@@ -25,7 +25,7 @@
     # Testing: GA solution with various mutations
     for muts in [inversion, insertion, swap2, scramble, shifting]
         result, fitness, cnt = ga(nqueens, N;
-            initPopulation = generatePositions,
+            creation = generatePositions,
             populationSize = P,
             selection = sus,
             crossover = pmx,
@@ -38,7 +38,7 @@
     # Testing: ES
     for muts in [inversion, insertion, swap2, scramble, shifting]
         result, fitness, cnt = es(nqueens, N;
-            initPopulation = generatePositions,
+            creation = generatePositions,
             mutation = mutationwrapper(muts),
             μ = 15, ρ = 1, λ = P)
         println("(15+$(P))-ES:$(string(muts)) => F: $(fitness), C: $(cnt), OBJ: $(result)")

--- a/test/rosenbrock.jl
+++ b/test/rosenbrock.jl
@@ -25,8 +25,8 @@
 	# Testing: (15/15+100)-σ-Self-Adaptation-ES
 	# with isotropic mutation operator y' := y + σ(N_1(0, 1), ..., N_N(0, 1))
 	result, fitness, cnt = es(rosenbrock, N;
-		initPopulation = [.5, .5],
-        initStrategy = strategy(σ = 1.0, τ = 1/sqrt(2*N)),
+		initStrategy = strategy(σ = 1.0, τ = 1/sqrt(2*N)),
+		creation = (n -> 0.5 .* rand(n)),
 		recombination = average, srecombination = averageSigma1,
 		mutation = isotropic, smutation = isotropicSigma,
 		μ = 15, λ = 100, iterations = 1000)
@@ -36,7 +36,7 @@
 	# Testing: (15/15+100)-σ-Self-Adaptation-ES
 	# with non-isotropic mutation operator y' := y + (σ_1 N_1(0, 1), ..., σ_N N_N(0, 1))
 	result, fitness, cnt = es(rosenbrock, N;
-		initPopulation = rand(N,25),
+		initPopulation = [rand(N) for _ in 1:15],
         initStrategy = strategy(σ = .5ones(N), τ = 1/sqrt(2*N), τ0 = 1/sqrt(N)),
 		recombination = average, srecombination = averageSigmaN,
 		mutation = anisotropic, smutation = anisotropicSigma,
@@ -51,14 +51,13 @@
     test_result(result, fitness, N, 1e-1)
 
     # Testing: GA
-    result, fitness, cnt = ga(rosenbrock, N;
-    	initPopulation = (n -> rand(n)),
-    	populationSize = 100,
-    	ɛ = 0.1,
+	result, fitness, cnt = ga(rosenbrock, N;
+		populationSize = 100,
+		ɛ = 0.1,
         selection = sus,
         crossover = intermediate(0.25),
         mutation = domainrange(fill(0.5,N)))
     println("GA(p=50,x=0.8,μ=0.1) => F: $(fitness), C: $(cnt), OBJ: $(result)")
-    test_result(result, fitness, N, 3e-1)
+    test_result(result, fitness, N, 1e-1)
 
 end


### PR DESCRIPTION
`initPopulation` was a heavily overloaded parameter, with a variety of
types corresponding to a range of possible behaviours. This commit:
- Removes the option to pass a vector representing the search space.
This is specific and unclear, and behaviour can easily be easily
represented by one of the other options
- Restricts `initPopulation` to be a vector of individuals (where an
individual is a single member of the population)
- Adds a new parameter `creation` to represent a function to create an
individual.

Default behaviour has not been changed, but is now represented by a
creation function.