### PR TITLE
Parameterised type

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,0 +1,23 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,14 @@
+name = "Evolutionary"
+uuid = "86b6b26d-c046-49b6-aa0b-5f0f74682bd6"
+version = "0.2.0"
+
+[deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -4,8 +4,8 @@ version = "0.2.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/README.md
+++ b/README.md
@@ -8,8 +8,15 @@ A Julia package for [evolutionary](http://www.scholarpedia.org/article/Evolution
 
 ## Installation
 
+For julia 0.6 and lower, run following command
+
 ```julia
 Pkg.add("Evolutionary")
+```
+
+For julia 0.7 and higher, run in the package manager mode
+```
+pkg> add https://github.com/wildart/Evolutionary.jl.git#v0.2.0
 ```
 
 ## Functionalities

--- a/src/Evolutionary.jl
+++ b/src/Evolutionary.jl
@@ -17,7 +17,6 @@ using Random
            es, cmaes, ga
 
     const Strategy = Dict{Symbol,Any}
-    const Individual = Union{Vector, Matrix, Function, Nothing}
 
     # Wrapping function for strategy
     function strategy(; kwargs...)
@@ -37,20 +36,14 @@ using Random
     end
 
     # Obtain individual
-    function getIndividual(init::Individual, N::Int)
-        if isa(init, Vector)
-            @assert length(init) == N "Dimensionality of initial population must be $(N)"
-            individual = init
-        elseif isa(init, Matrix)
-            @assert size(init, 1) == N "Dimensionality of initial population must be $(N)"
-            populationSize = size(init, 2)
-            individual = init[:, 1]
-        elseif isa(init, Function) # Creation function
-            individual = init(N)
+    function getIndividual(init::Union{Nothing, Vector}, creation::Function, N::Int)
+        if !isnothing(init)
+            individual = init[1]
+            @assert length(individual) == N "Dimensionality of initial population must be $(N)"
         else
-            individual = ones(N)
+            individual = creation(N)
         end
-        return  individual
+        return individual
     end
 
     # Collecting interim values

--- a/src/Evolutionary.jl
+++ b/src/Evolutionary.jl
@@ -29,21 +29,10 @@ using Random
 
     # Inverse function for reversing optimization direction
     function inverseFunc(f::Function)
-        function fitnessFunc(x::T) where {T <: Vector}
+        function fitnessFunc(x)
             return 1.0/(f(x)+eps())
         end
         return fitnessFunc
-    end
-
-    # Obtain individual
-    function getIndividual(init::Union{Nothing, Vector}, creation::Function, N::Int)
-        if !isnothing(init)
-            individual = init[1]
-            @assert length(individual) == N "Dimensionality of initial population must be $(N)"
-        else
-            individual = creation(N)
-        end
-        return individual
     end
 
     # Collecting interim values

--- a/src/Evolutionary.jl
+++ b/src/Evolutionary.jl
@@ -12,7 +12,7 @@ using Random
            discrete, waverage, intermediate, line,
            pmx, ox1, cx, ox2, pos,
            # GA selections
-           ranklinear, uniformranking, roulette, sus, tournament, #truncation
+           ranklinear, rankuniform, roulette, sus, tournament, #truncation
            # Optimization methods
            es, cmaes, ga
 

--- a/src/cmaes.jl
+++ b/src/cmaes.jl
@@ -9,8 +9,9 @@
 using LinearAlgebra
 using Statistics
 function cmaes( objfun::Function, N::Int;
-                initPopulation::Individual = ones(N),
+                initPopulation::Union{Nothing, Vector} = nothing,
                 initStrategy::Strategy = strategy(τ = sqrt(N), τ_c = N^2, τ_σ = sqrt(N)),
+                creation::Function = (n -> rand(n)),
                 μ::Integer = 1,
                 λ::Integer = 1,
                 iterations::Integer = 1_000,
@@ -20,7 +21,7 @@ function cmaes( objfun::Function, N::Int;
     @assert μ < λ "Offspring population must be larger then parent population"
 
     # Initialize parent population
-    individual = getIndividual(initPopulation, N)
+    individual = getIndividual(initPopulation, creation, N)
     population = fill(individual, μ)
     offspring = Array{typeof(individual)}(undef, λ)
     fitpop = fill(Inf, μ)

--- a/src/cmaes.jl
+++ b/src/cmaes.jl
@@ -8,26 +8,31 @@
 #
 using LinearAlgebra
 using Statistics
-function cmaes( objfun::Function, N::Int;
-                initPopulation::Union{Nothing, Vector} = nothing,
-                initStrategy::Strategy = strategy(τ = sqrt(N), τ_c = N^2, τ_σ = sqrt(N)),
-                creation::Function = (n -> rand(n)),
+function cmaes( objfun::Function, individual::T;
+                initParent::Union{Nothing, T} = nothing,
+                initStrategy::Strategy = strategy(τ = sqrt(length(individual)), τ_c = length(individual)^2, τ_σ = sqrt(length(individual))),
+                creation::Function = (n -> rand(eltype(T), n)),
                 μ::Integer = 1,
                 λ::Integer = 1,
                 iterations::Integer = 1_000,
                 tol::Float64 = 1e-10,
-                verbose = false)
+                verbose = false) where {T}
 
     @assert μ < λ "Offspring population must be larger then parent population"
+    @assert ndims(individual) == 1 "Individual must be 1D"
 
     # Initialize parent population
-    individual = getIndividual(initPopulation, creation, N)
-    population = fill(individual, μ)
-    offspring = Array{typeof(individual)}(undef, λ)
+    N = length(individual)
+    population = Array{T}(undef, μ)
+    offspring = Array{T}(undef, λ)
     fitpop = fill(Inf, μ)
     fitoff = fill(Inf, λ)
 
-    parent = copy(individual)
+    if !isnothing(initParent) 
+        parent = initParent
+    else
+        parent = creation(N)
+    end
     C = Diagonal{Float64}(I, N)
     s = zeros(N)
     s_σ = zeros(N)

--- a/src/cmaes.jl
+++ b/src/cmaes.jl
@@ -84,5 +84,9 @@ function cmaes( objfun::Function, individual::T;
         verbose && println("BEST: $(fitness[1]): $(σ)")
     end
 
-    return population[1], fitness[1], itr
+    return (
+        bestIndividual=population[1],
+        bestFitness=fitness[1],
+        itr=itr
+    )
 end

--- a/src/cmaes.jl
+++ b/src/cmaes.jl
@@ -73,7 +73,7 @@ function cmaes( objfun::Function, N::Int;
 
         # termination condition
         count += 1
-        if count == iterations || σ < tol
+        if count == iterations || σ <= tol
             break
         end
         verbose && println("BEST: $(fitpop[1]): $(σ)")

--- a/src/cmaes.jl
+++ b/src/cmaes.jl
@@ -25,7 +25,7 @@ function cmaes( objfun::Function, individual::T;
     N = length(individual)
     population = Array{T}(undef, μ)
     offspring = Array{T}(undef, λ)
-    fitpop = fill(Inf, μ)
+    fitness = fill(Inf, μ)
     fitoff = fill(Inf, λ)
 
     if !isnothing(initParent) 
@@ -41,7 +41,7 @@ function cmaes( objfun::Function, individual::T;
     W = zeros(N, λ)
 
     # Generation cycle
-    count = 0
+    itr = 0
     while true
         SqrtC = (C + C') / 2.0
         try
@@ -63,7 +63,7 @@ function cmaes( objfun::Function, individual::T;
         idx = sortperm(fitoff)[1:μ]
         for i in 1:μ
             population[i] = offspring[idx[i]]
-            fitpop[i] = fitoff[idx[i]]
+            fitness[i] = fitoff[idx[i]]
         end
 
         w = vec(mean(W[:,idx], dims=2))
@@ -77,12 +77,12 @@ function cmaes( objfun::Function, individual::T;
         σ = σ*exp(((s_σ'*s_σ)[1] - N)/(2*N*sqrt(N)))                           # (L6)
 
         # termination condition
-        count += 1
-        if count == iterations || σ <= tol
+        itr += 1
+        if itr == iterations || σ <= tol
             break
         end
-        verbose && println("BEST: $(fitpop[1]): $(σ)")
+        verbose && println("BEST: $(fitness[1]): $(σ)")
     end
 
-    return population[1], fitpop[1], count
+    return population[1], fitness[1], itr
 end

--- a/src/es.jl
+++ b/src/es.jl
@@ -39,10 +39,10 @@ function es(  objfun::Function, N::Int;
     population = fill(individual, μ)
     fitness = zeros(μ)
     for i in 1:μ
-        if !isnothing(initPopulation)
-            population[i] = initPopulation[i]
-        else
+        if isnothing(initPopulation) 
             population[i] = creation(N)
+        else
+            population[i] = initPopulation[i]
         end
         fitness[i] = objfun(population[i])
         debug && println("INIT $(i): $(population[i]) : $(fitness[i])")

--- a/src/es.jl
+++ b/src/es.jl
@@ -110,5 +110,10 @@ function es(  objfun::Function, individual::T;
         verbose && println("BEST: $(fitness[1]): $(stgpop[1])")
     end
 
-    return population[1], fitness[1], itr, store
+    return (
+        bestIndividual=population[1],
+        bestFitness=fitness[1],
+        itr=itr,
+        store=store
+    )
 end

--- a/src/es.jl
+++ b/src/es.jl
@@ -11,13 +11,14 @@
 # Plus-selection: parents are deterministically selected from the set of both the parents and offspring
 #
 function es(  objfun::Function, N::Int;
-              initPopulation::Individual = ones(N),
+              initPopulation::Union{Nothing, Vector} = nothing,
               initStrategy::Strategy = strategy(),
-              recombination::Function = (rs->rs[1]),
-              srecombination::Function = (ss->ss[1]),
-              mutation::Function = ((r,m)->r),
-              smutation::Function = (s->s),
-              termination::Function = (x->false),
+              creation::Function = (n -> rand(n)),
+              recombination::Function = (rs -> rs[1]),
+              srecombination::Function = (ss -> ss[1]),
+              mutation::Function = ((r, m) -> r),
+              smutation::Function = (s -> s),
+              termination::Function = (x -> false),
               μ::Integer = 1,
               ρ::Integer = μ,
               λ::Integer = 1,
@@ -34,16 +35,14 @@ function es(  objfun::Function, N::Int;
     store = Dict{Symbol,Any}()
 
     # Initialize parent population
-    individual = getIndividual(initPopulation, N)
+    individual = getIndividual(initPopulation, creation, N)
     population = fill(individual, μ)
     fitness = zeros(μ)
     for i in 1:μ
-        if isa(initPopulation, Vector)
-            population[i] = initPopulation.*rand(N)
-        elseif isa(initPopulation, Matrix)
-            population[i] = initPopulation[:, i]
-        else # Creation function
-            population[i] = initPopulation(N)
+        if !isnothing(initPopulation)
+            population[i] = initPopulation[i]
+        else
+            population[i] = creation(N)
         end
         fitness[i] = objfun(population[i])
         debug && println("INIT $(i): $(population[i]) : $(fitness[i])")

--- a/src/es.jl
+++ b/src/es.jl
@@ -55,7 +55,7 @@ function es(  objfun::Function, individual::T;
     keep(interim, :fitness, copy(fitness), store)
 
     # Generation cycle
-    count = 0
+    itr = 0
     while true
 
         for i in 1:λ
@@ -103,12 +103,12 @@ function es(  objfun::Function, individual::T;
         keep(interim, :fitoff, copy(fitoff), store)
 
         # termination condition
-        count += 1
-        if count == iterations || termination(stgpop[1])
+        itr += 1
+        if itr == iterations || termination(stgpop[1])
             break
         end
         verbose && println("BEST: $(fitness[1]): $(stgpop[1])")
     end
 
-    return population[1], fitness[1], count, store
+    return population[1], fitness[1], itr, store
 end

--- a/src/ga.jl
+++ b/src/ga.jl
@@ -1,7 +1,7 @@
 # Genetic Algorithms
 # ==================
 #         objfun: Objective fitness function
-#              N: Search space dimensionality
+#     individual: Sample data structure representing an individual
 # initPopulation: Initial population values as matrix
 # populationSize: Size of the population
 #  crossoverRate: The fraction of the population at the next generation, not including elite children,
@@ -11,41 +11,41 @@
 #                 are guaranteed to survive to the next generation.
 #                 Floating number specifies fraction of population.
 #
-function ga(objfun::Function, N::Int;
-            initPopulation::Union{Nothing, Vector} = nothing,
-            lowerBounds::Union{Nothing, Vector} = nothing,
-            upperBounds::Union{Nothing, Vector} = nothing,
+function ga(objfun::Function, individual::T;
+            initPopulation::Union{Nothing, Vector{T}} = nothing,
+            lowerBounds::Union{Nothing, Vector{T}} = nothing,
+            upperBounds::Union{Nothing, Vector{T}} = nothing,
             populationSize::Int = 50,
             crossoverRate::Float64 = 0.8,
             mutationRate::Float64 = 0.1,
             ɛ::Real = 0,
-            creation::Function = (n -> rand(n)),
+            creation::Function = (dims -> rand(eltype(T), dims)),
             selection::Function = ((x, n) -> 1:n),
             crossover::Function = ((x, y) -> (y, x)),
             mutation::Function = (x -> x),
-            iterations::Integer = 100*N,
+            iterations::Integer = 100*prod(size(individual)),
             tol = 0.0,
             tolIter = 10,
             verbose = false,
             debug = false,
-            interim = false)
+            interim = false) where {T}
 
-    store = Dict{Symbol,Any}()
+    store = Dict{Symbol, Any}()
 
     # Setup parameters
+    dims = size(individual)
     elite = isa(ɛ, Int) ? ɛ : round(Int, ɛ * populationSize)
     fitFunc = inverseFunc(objfun)
 
     # Initialize population
-    individual = getIndividual(initPopulation, creation, N)
     fitness = zeros(populationSize)
-    population = Array{typeof(individual)}(undef, populationSize)
+    population = Array{T}(undef, populationSize)
     offspring = similar(population)
 
     # Generate population
     for i in 1:populationSize
         if isnothing(initPopulation) 
-            population[i] = creation(N)
+            population[i] = creation(dims)
         else
             population[i] = initPopulation[i]
         end

--- a/src/ga.jl
+++ b/src/ga.jl
@@ -44,10 +44,10 @@ function ga(objfun::Function, N::Int;
 
     # Generate population
     for i in 1:populationSize
-        if !isnothing(initPopulation) 
-            population[i] = initPopulation[i]
-        else
+        if isnothing(initPopulation) 
             population[i] = creation(N)
+        else
+            population[i] = initPopulation[i]
         end
         fitness[i] = fitFunc(population[i])
         debug && println("INIT $(i): $(population[i]) : $(fitness[i])")

--- a/src/ga.jl
+++ b/src/ga.jl
@@ -25,7 +25,7 @@ function ga(objfun::Function, individual::T;
             mutation::Function = (x -> x),
             iterations::Integer = 100*prod(size(individual)),
             tol = 0.0,
-            tolIter = 10,
+            tolitr = 10,
             verbose = false,
             debug = false,
             interim = false) where {T}
@@ -56,7 +56,7 @@ function ga(objfun::Function, individual::T;
     keep(interim, :fitness, copy(fitness), store)
 
     # Generate and evaluate offspring
-    itr = 1
+    itr = 0
     bestFitness = 0.0
     bestIndividual = 0
     fittol = 0.0
@@ -114,12 +114,13 @@ function ga(objfun::Function, individual::T;
         keep(interim, :bestFitness, bestFitness, store)
 
         # Verbose step
-        verbose &&  println("BEST: $(bestFitness): $(population[bestIndividual]), G: $(itr)")
+        verbose && println("BEST: $(bestFitness): $(population[bestIndividual]), G: $(itr)")
 
         # Terminate:
         #  if fitness tolerance is met for specified number of steps
+        itr += 1
         if fittol <= tol
-            if (tolIter != -1) && (fittolitr > tolIter)
+            if (tolitr != -1) && (fittolitr > tolitr)
                 break
             else
                 fittolitr += 1
@@ -131,7 +132,6 @@ function ga(objfun::Function, individual::T;
         if itr >= iterations
             break
         end
-        itr += 1
     end
 
     return population[bestIndividual], bestFitness, itr, fittol, store

--- a/src/ga.jl
+++ b/src/ga.jl
@@ -134,5 +134,11 @@ function ga(objfun::Function, individual::T;
         end
     end
 
-    return population[bestIndividual], bestFitness, itr, fittol, store
+    return (
+        bestIndividual=population[bestIndividual],
+        bestFitness=bestFitness,
+        itr=itr,
+        fittol=fittol,
+        store=store
+    )
 end

--- a/src/ga.jl
+++ b/src/ga.jl
@@ -118,8 +118,8 @@ function ga(objfun::Function, N::Int;
 
         # Terminate:
         #  if fitness tolerance is met for specified number of steps
-        if fittol < tol
-            if fittolitr > tolIter
+        if fittol <= tol
+            if (tolIter != -1) && (fittolitr > tolIter)
                 break
             else
                 fittolitr += 1

--- a/src/selections.jl
+++ b/src/selections.jl
@@ -1,4 +1,4 @@
-# GA seclections
+# GA selections
 # ==============
 
 # Rank-based fitness assignment
@@ -7,12 +7,24 @@ function ranklinear(sp::Float64)
     @assert 1.0 <= sp <= 2.0 "Selective pressure has to be in range [1.0, 2.0]."
     function rank(fitness::Vector{Float64}, N::Int)
         λ = length(fitness)
+<<<<<<< Updated upstream
+        rank = sortperm(fitness)
+        
+        prob = Vector{Float64}(undef, λ)
+=======
         idx = sortperm(fitness)
-        ranks = zeros(λ)
+
+        ranks = Vector{Float64}(undef, λ)
+>>>>>>> Stashed changes
         for i in 1:λ
-            ranks[i] = ( 2.0- sp + 2.0*(sp - 1.0)*(idx[i] - 1.0) / (λ - 1.0) ) / λ
+            prob[i] = ( 2.0- sp + 2.0*(sp - 1.0)*(rank[i] - 1.0) / (λ - 1.0) ) / λ
         end
+
+<<<<<<< Updated upstream
+        return pselection(prob, N)
+=======
         return pselection(ranks, N)
+>>>>>>> Stashed changes
     end
     return rank
 end
@@ -21,13 +33,18 @@ end
 function uniformranking(μ::Int)
     function uniformrank(fitness::Vector{Float64}, N::Int)
         λ = length(fitness)
-        idx = sortperm(fitness, rev=true)
+<<<<<<< Updated upstream
         @assert μ < λ "μ should be less then $(λ)"
-        ranks = zeros(fitness)
-        for i in 1:μ
-            ranks[idx[i]] = 1/μ
-        end
+
+        prob = fill(1/μ, μ)
+        return pselection(prob, N)
+=======
+        @assert μ < λ "μ should equal $(λ)"
+
+        ranks = fill(1/μ, μ)
+
         return pselection(ranks, N)
+>>>>>>> Stashed changes
     end
     return uniformrank
 end
@@ -40,11 +57,13 @@ end
 
 # Stochastic universal sampling (SUS)
 function sus(fitness::Vector{Float64}, N::Int)
+    selected = Vector{Int}(undef, N)
+    
     F = sum(fitness)
     P = F/N
+    
     start = P*rand()
     pointers = [start+P*i for i = 0:(N-1)]
-    selected = Vector{Int}(undef, N)
     i = c = 1
     for P in pointers
         while sum(fitness[1:i]) < P
@@ -53,6 +72,7 @@ function sus(fitness::Vector{Float64}, N::Int)
         selected[c] = i
         c += 1
     end
+
     return selected
 end
 

--- a/src/selections.jl
+++ b/src/selections.jl
@@ -44,7 +44,7 @@ function sus(fitness::Vector{Float64}, N::Int)
     P = F/N
     start = P*rand()
     pointers = [start+P*i for i = 0:(N-1)]
-    selected = Array{Int}(undef, N)
+    selected = Vector{Int}(undef, N)
     i = c = 1
     for P in pointers
         while sum(fitness[1:i]) < P
@@ -65,7 +65,7 @@ end
 function tournament(groupSize :: Int)
     groupSize <= 0 && error("Group size needs to be positive")
     function tournamentN(fitness::Vector{Float64}, N::Int)
-        selection = Array{Int}(N)
+        selection = Vector{Int}(undef, N)
 
         nFitness = length(fitness)
 
@@ -96,7 +96,7 @@ end
 # Utils: selection
 function pselection(prob::Vector{Float64}, N::Int)
     cp = cumsum(prob)
-    selected = Array{Int}(undef, N)
+    selected = Vector{Int}(undef, N)
     for i in 1:N
         j = 1
         r = rand()

--- a/src/selections.jl
+++ b/src/selections.jl
@@ -95,15 +95,24 @@ end
 
 # Utils: selection
 function pselection(prob::Vector{Float64}, N::Int)
-    cp = cumsum(prob)
     selected = Vector{Int}(undef, N)
+
+    cp = cumsum(prob)
+    @assert cp[end] ≈ 1 "Sum of probability vector must equal 1"
+
     for i in 1:N
-        j = 1
-        r = rand()
-        while cp[j] < r
-            j += 1
-        end
-        selected[i] = j
+        selected[i] = vlookup(cp, rand())
     end
     return selected
+end
+
+# Utils: vlookup
+function vlookup(range::Vector{<:Number}, value::Number)
+    for i in eachindex(range)
+        if range[i] >= value
+            return i
+        end
+    end
+
+    return -1
 end

--- a/src/selections.jl
+++ b/src/selections.jl
@@ -7,46 +7,23 @@ function ranklinear(sp::Float64)
     @assert 1.0 <= sp <= 2.0 "Selective pressure has to be in range [1.0, 2.0]."
     function rank(fitness::Vector{Float64}, N::Int)
         λ = length(fitness)
-<<<<<<< Updated upstream
         rank = sortperm(fitness)
         
         prob = Vector{Float64}(undef, λ)
-=======
-        idx = sortperm(fitness)
-
-        ranks = Vector{Float64}(undef, λ)
->>>>>>> Stashed changes
         for i in 1:λ
             prob[i] = ( 2.0- sp + 2.0*(sp - 1.0)*(rank[i] - 1.0) / (λ - 1.0) ) / λ
         end
 
-<<<<<<< Updated upstream
         return pselection(prob, N)
-=======
-        return pselection(ranks, N)
->>>>>>> Stashed changes
     end
     return rank
 end
 
-# (μ, λ)-uniform ranking selection
-function uniformranking(μ::Int)
-    function uniformrank(fitness::Vector{Float64}, N::Int)
-        λ = length(fitness)
-<<<<<<< Updated upstream
-        @assert μ < λ "μ should be less then $(λ)"
-
-        prob = fill(1/μ, μ)
-        return pselection(prob, N)
-=======
-        @assert μ < λ "μ should equal $(λ)"
-
-        ranks = fill(1/μ, μ)
-
-        return pselection(ranks, N)
->>>>>>> Stashed changes
-    end
-    return uniformrank
+# uniform ranking selection
+function rankuniform(fitness::Vector{Float64}, N::Int)
+    μ = length(fitness)
+    prob = fill(1/μ, μ)
+    return pselection(prob, N)
 end
 
 # Roulette wheel (proportionate selection) selection

--- a/test/knapsack.jl
+++ b/test/knapsack.jl
@@ -20,6 +20,7 @@
         crossoverRate = 0.5,
         ɛ = 0.1,                                # Elitism
         iterations = 20,
+        tolIter = 20,
         populationSize = 50,
         interim = true);
 

--- a/test/knapsack.jl
+++ b/test/knapsack.jl
@@ -7,12 +7,12 @@
         return (total_mass <= 20) ? sum(utility .* n) : 0
     end
 
-    initpop = collect(rand(Bool,length(mass)))
+    creation = n -> rand(Bool, n)
 
     best, invbestfit, generations, tolerance, history = ga(
         x -> 1 / fitness(x),                    # Function to MINIMISE
-        length(initpop),                        # Length of chromosome
-        initPopulation = initpop,
+        length(mass),                           # Length of chromosome
+        creation = creation,
         selection = roulette,                   # Options: sus
         mutation = inversion,                   # Options:
         crossover = singlepoint,                # Options:

--- a/test/knapsack.jl
+++ b/test/knapsack.jl
@@ -20,7 +20,7 @@
         crossoverRate = 0.5,
         ɛ = 0.1,                                # Elitism
         iterations = 20,
-        tolIter = 20,
+        tolitr = 20,
         populationSize = 50,
         interim = true);
 

--- a/test/knapsack.jl
+++ b/test/knapsack.jl
@@ -11,7 +11,7 @@
 
     best, invbestfit, generations, tolerance, history = ga(
         x -> 1 / fitness(x),                    # Function to MINIMISE
-        length(mass),                           # Length of chromosome
+        Array{Bool}(undef, length(mass)),       # Solution structure
         creation = creation,
         selection = roulette,                   # Options: sus
         mutation = inversion,                   # Options:

--- a/test/n-queens.jl
+++ b/test/n-queens.jl
@@ -2,7 +2,7 @@
 
     N = 8
     P = 100
-    generatePositions(N::Int) = collect(1:N)[randperm(N)]
+    generatePositions(N::Int, _=nothing) = collect(1:N)[randperm(N)]
 
     # Vector of N cols filled with numbers from 1:N specifying row position
     function nqueens(queens::Vector{Int})

--- a/test/n-queens.jl
+++ b/test/n-queens.jl
@@ -25,8 +25,8 @@
     # Testing: GA solution with various mutations
     for muts in [inversion, insertion, swap2, scramble, shifting]
         result, fitness, cnt = ga(nqueens, N;
-            initPopulation = generatePositions,
             populationSize = P,
+            creation = generatePositions,
             selection = sus,
             crossover = pmx,
             mutation = muts)
@@ -37,7 +37,7 @@
     # Testing: ES
     for muts in [inversion, insertion, swap2, scramble, shifting]
         result, fitness, cnt = es(nqueens, N;
-            initPopulation = generatePositions,
+            creation = generatePositions,
             mutation = mutationwrapper(muts),
             μ = 15, ρ = 1, λ = P)
         println("(15+$(P))-ES:$(string(muts)) => F: $(fitness), C: $(cnt), OBJ: $(result)")

--- a/test/n-queens.jl
+++ b/test/n-queens.jl
@@ -2,10 +2,10 @@
 
     N = 8
     P = 100
-    generatePositions(N::Int, _=nothing) = collect(1:N)[randperm(N)]
+    generatePositions((N,)::Tuple{<:Integer}) = collect(1:N)[randperm(N)]
 
     # Vector of N cols filled with numbers from 1:N specifying row position
-    function nqueens(queens::Vector{Int})
+    function nqueens(queens::Vector{<:Integer})
         n = length(queens)
         fitness = 0
         for i=1:(n-1)
@@ -24,7 +24,7 @@
 
     # Testing: GA solution with various mutations
     for muts in [inversion, insertion, swap2, scramble, shifting]
-        result, fitness, cnt = ga(nqueens, N;
+        result, fitness, cnt = ga(nqueens, Vector{Int}(undef, N);
             populationSize = P,
             creation = generatePositions,
             selection = sus,
@@ -37,7 +37,7 @@
 
     # Testing: ES
     for muts in [inversion, insertion, swap2, scramble, shifting]
-        result, fitness, cnt = es(nqueens, N;
+        result, fitness, cnt = es(nqueens, Vector{Int}(undef, N);
             creation = generatePositions,
             mutation = mutationwrapper(muts),
             μ = 15, ρ = 1, λ = P)

--- a/test/n-queens.jl
+++ b/test/n-queens.jl
@@ -1,7 +1,7 @@
 @testset "n-Queens" begin
 
     N = 8
-    P = 50
+    P = 100
     generatePositions(N::Int) = collect(1:N)[randperm(N)]
 
     # Vector of N cols filled with numbers from 1:N specifying row position
@@ -32,6 +32,7 @@
             mutation = muts)
         println("GA:PMX:$(string(muts))(N=$(N), P=$(P)) => F: $(fitness), C: $(cnt), OBJ: $(result)")
         @test nqueens(result) == 0
+        @test cnt < 800 # Test early stopping
     end
 
     # Testing: ES

--- a/test/rastrigin.jl
+++ b/test/rastrigin.jl
@@ -38,7 +38,7 @@
     test_result(result, fitness, N, 1e-1)
 
     # Testing: GA
-    selections = [roulette, sus, ranklinear(1.5)]
+    selections = [roulette, sus, ranklinear(1.5), rankuniform, tournament(4)]
     crossovers = [discrete, intermediate(0.), intermediate(0.25), line(0.2)]
     mutations = [domainrange(fill(0.5,N)), domainrange(fill(1.0,N))]
 

--- a/test/rastrigin.jl
+++ b/test/rastrigin.jl
@@ -5,7 +5,7 @@
             @test ≈(result, zeros(N), atol=tol)
             @test ≈(fitness,0.0, atol=tol)
         else
-            @warn("Found local minimum!!!")
+            # @warn("Found local minimum!!!")
             @test sum(round.(abs.(result))) < N
         end
     end
@@ -50,7 +50,7 @@
                 crossover = xovr,
                 mutation = ms,
                 tol = 1e-5)
-        # println("GA(p=$(P),x=.8,μ=.1,ɛ=0.1) => F: $(fitness), C: $(cnt), OBJ: $(result)")
+        println("GA(p=$(P),x=.8,μ=.1,ɛ=0.1) => F: $(fitness), C: $(cnt), OBJ: $(result)")
         test_result(result, fitness, N, 1e-1)
     end
 end

--- a/test/rastrigin.jl
+++ b/test/rastrigin.jl
@@ -22,7 +22,7 @@
 
     # Testing: (μ/μ_I,λ)-σ-Self-Adaptation-ES
     # with non-isotropic mutation operator y' := y + (σ_1 N_1(0, 1), ..., σ_N N_N(0, 1))
-    result, fitness, cnt = es( rastrigin, N;
+    result, fitness, cnt = es( rastrigin, Vector{Float64}(undef, N);
             initStrategy = strategy(σ = .5ones(N), τ = 1/sqrt(2*N), τ0 = 1/sqrt(N)),
             recombination = average, srecombination = averageSigmaN,
             mutation = anisotropic, smutation = anisotropicSigma,
@@ -33,7 +33,8 @@
     test_result(result, fitness, N, 1e-1)
 
     # Testing: CMA-ES
-    result, fitness, cnt = cmaes( rastrigin, N; μ = 15, λ = P, tol = 1e-8)
+    result, fitness, cnt = cmaes( rastrigin, Vector{Float64}(undef, N);
+            μ = 15, λ = P, tol = 1e-8)
     println("(15/15,$(P))-CMA-ES => F: $(fitness), C: $(cnt), OBJ: $(result)")
     test_result(result, fitness, N, 1e-1)
 
@@ -43,7 +44,7 @@
     mutations = [domainrange(fill(0.5,N)), domainrange(fill(1.0,N))]
 
     @testset "GA settings" for ss in selections, xovr in crossovers, ms in mutations
-        result, fitness, cnt = ga( rastrigin, N;
+        result, fitness, cnt = ga( rastrigin, Vector{Float64}(undef, N);
                 populationSize = P,
                 ɛ = 0.1,
                 selection = ss,

--- a/test/rosenbrock.jl
+++ b/test/rosenbrock.jl
@@ -15,7 +15,7 @@
 
 	# Testing: (15/5+100)-ES
 	# with isotropic mutation operator y' := y + σ(N_1(0, 1), ..., N_N(0, 1))
-	result, fitness, cnt = es(rosenbrock, N;
+	result, fitness, cnt = es(rosenbrock, Vector{Float64}(undef, N);
         initStrategy = strategy(σ = 1.0),
         recombination = average, mutation = isotropic,
         μ = 15, ρ = 5, λ = 100, iterations = 1000)
@@ -24,9 +24,9 @@
 
 	# Testing: (15/15+100)-σ-Self-Adaptation-ES
 	# with isotropic mutation operator y' := y + σ(N_1(0, 1), ..., N_N(0, 1))
-	result, fitness, cnt = es(rosenbrock, N;
+	result, fitness, cnt = es(rosenbrock, Vector{Float64}(undef, N);
 		initStrategy = strategy(σ = 1.0, τ = 1/sqrt(2*N)),
-		creation = (n -> 0.5 .* rand(n)),
+		creation = (n -> 0.5 .* rand(Float64, n)),
 		recombination = average, srecombination = averageSigma1,
 		mutation = isotropic, smutation = isotropicSigma,
 		μ = 15, λ = 100, iterations = 1000)
@@ -35,7 +35,7 @@
 
 	# Testing: (15/15+100)-σ-Self-Adaptation-ES
 	# with non-isotropic mutation operator y' := y + (σ_1 N_1(0, 1), ..., σ_N N_N(0, 1))
-	result, fitness, cnt = es(rosenbrock, N;
+	result, fitness, cnt = es(rosenbrock, Vector{Float64}(undef, N);
 		initPopulation = [rand(N) for _ in 1:15],
         initStrategy = strategy(σ = .5ones(N), τ = 1/sqrt(2*N), τ0 = 1/sqrt(N)),
 		recombination = average, srecombination = averageSigmaN,
@@ -45,13 +45,13 @@
 	test_result(result, fitness, N, 1e-1)
 
 	# Testing: CMA-ES
-	result, fitness, cnt = cmaes(rosenbrock, N;
+	result, fitness, cnt = cmaes(rosenbrock, Vector{Float64}(undef, N);
     	μ = 3, λ = 12, iterations = 100_000, tol = 1e-3)
     println("(3/3,12)-CMA-ES => F: $(fitness), C: $(cnt), OBJ: $(result)")
     test_result(result, fitness, N, 1e-1)
 
     # Testing: GA
-    result, fitness, cnt = ga(rosenbrock, N;
+    result, fitness, cnt = ga(rosenbrock, Vector{Float64}(undef, N);
     	populationSize = 100,
 		ɛ = 0.1,
         selection = sus,

--- a/test/rosenbrock.jl
+++ b/test/rosenbrock.jl
@@ -25,8 +25,8 @@
 	# Testing: (15/15+100)-σ-Self-Adaptation-ES
 	# with isotropic mutation operator y' := y + σ(N_1(0, 1), ..., N_N(0, 1))
 	result, fitness, cnt = es(rosenbrock, N;
-		initPopulation = [.5, .5],
-        initStrategy = strategy(σ = 1.0, τ = 1/sqrt(2*N)),
+		initStrategy = strategy(σ = 1.0, τ = 1/sqrt(2*N)),
+		creation = (n -> 0.5 .* rand(n)),
 		recombination = average, srecombination = averageSigma1,
 		mutation = isotropic, smutation = isotropicSigma,
 		μ = 15, λ = 100, iterations = 1000)
@@ -36,7 +36,7 @@
 	# Testing: (15/15+100)-σ-Self-Adaptation-ES
 	# with non-isotropic mutation operator y' := y + (σ_1 N_1(0, 1), ..., σ_N N_N(0, 1))
 	result, fitness, cnt = es(rosenbrock, N;
-		initPopulation = rand(N,25),
+		initPopulation = [rand(N) for _ in 1:15],
         initStrategy = strategy(σ = .5ones(N), τ = 1/sqrt(2*N), τ0 = 1/sqrt(N)),
 		recombination = average, srecombination = averageSigmaN,
 		mutation = anisotropic, smutation = anisotropicSigma,
@@ -52,9 +52,8 @@
 
     # Testing: GA
     result, fitness, cnt = ga(rosenbrock, N;
-    	initPopulation = (n -> rand(n)),
     	populationSize = 100,
-    	ɛ = 0.1,
+		ɛ = 0.1,
         selection = sus,
         crossover = intermediate(0.25),
         mutation = domainrange(fill(0.5,N)))

--- a/test/schwefel.jl
+++ b/test/schwefel.jl
@@ -14,7 +14,8 @@
     N = 30
 
     # Testing: CMA-ES
-    result, fitness, cnt = cmaes(schwefel, N; μ = 3, λ = 12, iterations = 1000)
+    result, fitness, cnt = cmaes(schwefel, Vector{Float64}(undef, N);
+            μ = 3, λ = 12, iterations = 1000)
     println("(3/3,12)-CMA-ES (Schwefel) => F: $(fitness), C: $(cnt)")
 
     @test ≈(result, zeros(N), atol=1e-5)

--- a/test/sphere.jl
+++ b/test/sphere.jl
@@ -34,7 +34,7 @@
             selection = sus,
             crossover = intermediate(0.25),
             mutation = domainrange(fill(0.5,N)),
-            tol = 1e-5, tolIter = 15)
+            tol = 1e-5, tolitr = 15)
     println("GA(pop=$(P),xover=0.8,μ=0.1) => F: $(fitness), C: $(cnt)")
     test_result(result, fitness, N, 1e-2)
 

--- a/test/sphere.jl
+++ b/test/sphere.jl
@@ -16,7 +16,7 @@
 
     # Testing: (μ/μ_I, λ)-σ-Self-Adaptation-ES
     # with isotropic mutation operator y' := y + σ(N_1(0, 1), ..., N_N(0, 1))
-    result, fitness, cnt = es(sphere, N;
+    result, fitness, cnt = es(sphere, Vector{Float64}(undef, N);
         initStrategy = strategy(σ = 1.0, τ = 1/sqrt(2*N)),
         recombination = average, srecombination = averageSigma1,
         mutation = isotropic, smutation = isotropicSigma,
@@ -27,7 +27,7 @@
 
     # Testing: GA
     result, fitness, cnt =
-        ga( sphere, N;
+        ga( sphere, Vector{Float64}(undef, N);
             populationSize = 4P,
             mutationRate = 0.05,
             ɛ = 0.1,


### PR DESCRIPTION
The `getIndividual` function was performing unnecessary work, so is
factored out in this commit. Instead, a sample individual is passed
as a parameter. This has the added benefit of making it clear to a
reader what kind of data is being worked with.

Note: n-queens P increased to 200 due to flaky test.