### PR TITLE
Remove populationSize, which is computed but not used.

### DIFF
--- a/src/Evolutionary.jl
+++ b/src/Evolutionary.jl
@@ -43,7 +43,6 @@ using Random
             individual = init
         elseif isa(init, Matrix)
             @assert size(init, 1) == N "Dimensionality of initial population must be $(N)"
-            populationSize = size(init, 2)
             individual = init[:, 1]
         elseif isa(init, Function) # Creation function
             individual = init(N)


### PR DESCRIPTION
The getIndividual function from Evolutionary.jl can also be splitted to take advantage of the multiple dispatch, if you think this would be a good idea.