### PR TITLE
Enforce type stability for cmaes

### DIFF
--- a/src/cmaes.jl
+++ b/src/cmaes.jl
@@ -33,7 +33,8 @@ mutable struct CMAESState{T, TI, TT} <: AbstractOptimizerState
     fittest::TI
     function CMAESState(N::Int, τ::T1, τ_c::T2, τ_σ::T3, fitpop::Vector{T}, C::Matrix{T},
         s::Vector{T}, s_σ::Vector{T}, σ::T, parent::TI, fittest::TI) where {T, TI, T1, T2, T3}
-        new{T,TI,promote_type(T1,T2,T3)}(N, promote(τ, τ_c, τ_σ)..., fitpop, C,
+        T = promote_type(T1,T2,T3)
+        new{T,TI,T}(N, T(τ), T(τ_c), T(τ_σ), fitpop, C,
             s, s_σ, σ, parent, fittest)
     end
 end

--- a/src/cmaes.jl
+++ b/src/cmaes.jl
@@ -33,8 +33,8 @@ mutable struct CMAESState{T, TI, TT} <: AbstractOptimizerState
     fittest::TI
     function CMAESState(N::Int, τ::T1, τ_c::T2, τ_σ::T3, fitpop::Vector{T}, C::Matrix{T},
         s::Vector{T}, s_σ::Vector{T}, σ::T, parent::TI, fittest::TI) where {T, TI, T1, T2, T3}
-        T = promote_type(T1,T2,T3)
-        new{T,TI,T}(N, T(τ), T(τ_c), T(τ_σ), fitpop, C,
+        TP = promote_type(T1,T2,T3)
+        new{T,TI,TP}(N, TP(τ), TP(τ_c), TP(τ_σ), fitpop, C,
             s, s_σ, σ, parent, fittest)
     end
 end

--- a/src/cmaes.jl
+++ b/src/cmaes.jl
@@ -9,21 +9,21 @@ The constructor takes following keyword arguments:
 - `τ_c` is a time constant for a covariance matrix `C`
 - `τ_σ` is a time constant for a global step size `σ`
 """
-@kwdef struct CMAES <: AbstractOptimizer
-    μ::Integer = 1
-    λ::Integer = μ+1
-    τ::Real    = NaN
-    τ_c::Real  = NaN
-    τ_σ::Real  = NaN
+@kwdef struct CMAES{TT} <: AbstractOptimizer
+    μ::Int = 1
+    λ::Int = μ+1
+    τ::TT    = NaN
+    τ_c::TT  = NaN
+    τ_σ::TT  = NaN
 end
 population_size(method::CMAES) = method.μ
-default_options(method::CMAES) = Dict(:iterations=>1500, :abstol=>1e-10)
+default_options(method::CMAES) = (iterations=1500, abstol=1e-10)
 
-mutable struct CMAESState{T, TI} <: AbstractOptimizerState
+mutable struct CMAESState{T, TI, TT} <: AbstractOptimizerState
     N::Int
-    τ::Real
-    τ_c::Real
-    τ_σ::Real
+    τ::TT
+    τ_c::TT
+    τ_σ::TT
     fitpop::Vector{T}
     C::Matrix{T}
     s::Vector{T}
@@ -31,6 +31,11 @@ mutable struct CMAESState{T, TI} <: AbstractOptimizerState
     σ::T
     parent::TI
     fittest::TI
+    function CMAESState(N::Int, τ::T1, τ_c::T2, τ_σ::T3, fitpop::Vector{T}, C::Matrix{T},
+        s::Vector{T}, s_σ::Vector{T}, σ::T, parent::TI, fittest::TI) where {T, TI, T1, T2, T3}
+        new{T,TI,promote_type(T1,T2,T3)}(N, promote(τ, τ_c, τ_σ)..., fitpop, C,
+            s, s_σ, σ, parent, fittest)
+    end
 end
 value(s::CMAESState) = first(s.fitpop)
 minimizer(s::CMAESState) = s.fittest


### PR DESCRIPTION
The interfaces after refactoring are very nice!
The performance can be improved a lot if type stability are enforced.

## Test Code
```julia
using Random
Random.seed!(2)
N = 2
rosenbrock(x) = (1.0 - x[1])^2 + 100.0 * (x[2] - x[1]^2)^2
using Evolutionary
# termination condition
using BenchmarkTools
@benchmark result = Evolutionary.optimize(rosenbrock, randn(2), $(CMAES(;μ=5, λ=100)))
```

## Before
```julia repl
BenchmarkTools.Trial: 
  memory estimate:  34.43 MiB
  allocs estimate:  1124405
  --------------
  minimum time:     132.045 ms (4.46% GC)
  median time:      420.937 ms (4.47% GC)
  mean time:        444.512 ms (3.98% GC)
  maximum time:     757.132 ms (3.90% GC)
  --------------
  samples:          12
  evals/sample:     1
```

## After
```julia repl
BenchmarkTools.Trial: 
  memory estimate:  17.97 MiB
  allocs estimate:  207935
  --------------
  minimum time:     26.536 ms (0.00% GC)
  median time:      67.595 ms (11.88% GC)
  mean time:        66.158 ms (9.74% GC)
  maximum time:     96.395 ms (13.28% GC)
  --------------
  samples:          76
  evals/sample:     1
```