### PR TITLE
make function fields type stable

### DIFF
--- a/src/de.jl
+++ b/src/de.jl
@@ -10,16 +10,16 @@ The constructor takes following keyword arguments:
 - `recombination`: the recombination functions (default: [`uniformbin(0.5)`](@ref))
 - `K`: the recombination scale factor (default: 0.5*(F+1))
 """
-@kwdef struct DE <: AbstractOptimizer
+@kwdef struct DE{F1,F2} <: AbstractOptimizer
     populationSize::Integer = 50
     F::Real = 0.9
     n::Integer = 1
-    K::Real = 0.5*(F+1)
-    selection::Function = random
-    recombination::Function = uniformbin(0.5)
+    K::Real = 0.5 * (F + 1)
+    selection::F1 = random
+    recombination::F2 = uniformbin(0.5)
 end
 population_size(method::DE) = method.populationSize
-default_options(method::DE) = (abstol=1e-10,)
+default_options(method::DE) = (abstol = 1e-10,)
 summary(m::DE) = "DE/$(m.selection)/$(m.n)/$(m.recombination)"
 
 mutable struct DEState{T,IT} <: AbstractOptimizerState
@@ -60,7 +60,7 @@ function update_state!(objfun, constraints, state, population::AbstractVector{IT
         offspring[i] = copy(base)
         # println("$i => base:", offspring[i])
 
-        targets = randexcl(1:Np, [i], 2*n)
+        targets = randexcl(1:Np, [i], 2 * n)
         offspring[i] = differentiation(offspring[i], @view population[targets]; F=F)
         # println("$i => mutated:", offspring[i], ", targets:", targets)
 

--- a/src/es.jl
+++ b/src/es.jl
@@ -13,34 +13,35 @@ The constructor takes following keyword arguments:
 - `λ`/`lambda`: the number of offspring
 - `selection`: the selection strategy `:plus` or `:comma` (default: `:plus`)
 """
-struct ES <: AbstractOptimizer
+struct ES{F1,F2} <: AbstractOptimizer
     initStrategy::AbstractStrategy
     recombination::Function
     srecombination::Function
-    mutation::Function
-    smutation::Function
+    mutation::F1
+    smutation::F2
     μ::Integer
     ρ::Integer
     λ::Integer
     selection::Symbol
-
-    ES(; initStrategy::AbstractStrategy = NoStrategy(),
-        recombination::Function = first,
-        srecombination::Function = first,
-        mutation::Function = ((r,s) -> r),
-        smutation::Function = identity,
-        μ::Integer = 1,
-        mu::Integer = μ,
-        ρ::Integer = μ,
-        rho::Integer = ρ,
-        λ::Integer = 1,
-        lambda::Integer = λ,
-        selection::Symbol = :plus) =
-        new(initStrategy, recombination, srecombination, mutation, smutation,
-            mu, rho, lambda, selection)
 end
+
+ES(; initStrategy::AbstractStrategy=NoStrategy(),
+recombination::Function=first,
+srecombination::Function=first,
+mutation::Function=((r,s) -> r),
+smutation::Function=identity,
+μ::Integer=1,
+mu::Integer=μ,
+ρ::Integer=μ,
+rho::Integer=ρ,
+λ::Integer=1,
+lambda::Integer=λ,
+selection::Symbol=:plus) =
+ES(initStrategy, recombination, srecombination, mutation, smutation,
+    mu, rho, lambda, selection)
+
 population_size(method::ES) = method.μ
-default_options(method::ES) = (iterations=1000, abstol=1e-10)
+default_options(method::ES) = (iterations = 1000, abstol = 1e-10)
 summary(m::ES) = "($(m.μ)/$(m.ρ)$(m.selection == :plus ? '+' : ',')$(m.λ))-ES"
 
 mutable struct ESState{T,IT,ST} <: AbstractOptimizerState
@@ -112,7 +113,7 @@ function update_state!(objfun, constraints, state, population::AbstractVector{IT
     # Select new parent population
     if selection == :plus
         idxs = sortperm(vcat(state.fitness, fitoff))[1:μ]
-        skip = idxs[idxs.<=μ]
+        skip = idxs[idxs .<= μ]
         for i = 1:μ
             if idxs[i] ∉ skip
                 ii = idxs[i] - μ

--- a/src/es.jl
+++ b/src/es.jl
@@ -26,18 +26,18 @@ struct ES{F1,F2} <: AbstractOptimizer
 end
 
 ES(; initStrategy::AbstractStrategy=NoStrategy(),
-recombination::Function=first,
-srecombination::Function=first,
-mutation::Function=((r,s) -> r),
-smutation::Function=identity,
-μ::Integer=1,
-mu::Integer=μ,
-ρ::Integer=μ,
-rho::Integer=ρ,
-λ::Integer=1,
-lambda::Integer=λ,
-selection::Symbol=:plus) =
-ES(initStrategy, recombination, srecombination, mutation, smutation,
+    recombination::Function=first,
+    srecombination::Function=first,
+    mutation::Function=((r,s) -> r),
+    smutation::Function=identity,
+    μ::Integer=1,
+    mu::Integer=μ,
+    ρ::Integer=μ,
+    rho::Integer=ρ,
+    λ::Integer=1,
+    lambda::Integer=λ,
+    selection::Symbol=:plus) =
+    ES(initStrategy, recombination, srecombination, mutation, smutation,
     mu, rho, lambda, selection)
 
 population_size(method::ES) = method.μ

--- a/src/ga.jl
+++ b/src/ga.jl
@@ -11,23 +11,23 @@ The constructor takes following keyword arguments:
 - `crossover`: [Crossover](@ref) function (default: `identity`)
 - `mutation`: [Mutation](@ref) function (default: `identity`)
 """
-struct GA <: AbstractOptimizer
+struct GA{F1,F2,F3} <: AbstractOptimizer
     populationSize::Int
     crossoverRate::Float64
     mutationRate::Float64
     ɛ::Real
-    selection::Function
-    crossover::Function
-    mutation::Function
-
-    GA(; populationSize::Int=50, crossoverRate::Float64=0.8, mutationRate::Float64=0.1,
-        ɛ::Real=0, epsilon::Real=ɛ,
-        selection::Function = ((x,n)->1:n),
-        crossover::Function = identity, mutation::Function = identity) =
-        new(populationSize, crossoverRate, mutationRate, epsilon, selection, crossover, mutation)
+    selection::F1
+    crossover::F2
+    mutation::F3
 end
+
+GA(; populationSize::Int=50, crossoverRate::Float64=0.8, mutationRate::Float64=0.1,
+ɛ::Real=0, epsilon::Real=ɛ,
+selection::Function=((x,n) -> 1:n),
+crossover::Function=identity, mutation::Function=identity) =
+GA(populationSize, crossoverRate, mutationRate, epsilon, selection, crossover, mutation)
 population_size(method::GA) = method.populationSize
-default_options(method::GA) = (iterations=1000, abstol=1e-15)
+default_options(method::GA) = (iterations = 1000, abstol = 1e-15)
 summary(m::GA) = "GA[P=$(m.populationSize),x=$(m.crossoverRate),μ=$(m.mutationRate),ɛ=$(m.ɛ)]"
 
 mutable struct GAState{T,IT} <: AbstractOptimizerState
@@ -69,7 +69,7 @@ function update_state!(objfun, constraints, state, population::AbstractVector{IT
     offidx = randperm(populationSize)
     offspringSize = populationSize - state.eliteSize
     for i in 1:2:offspringSize
-        j = (i == offspringSize) ? i-1 : i+1
+        j = (i == offspringSize) ? i - 1 : i + 1
         if rand() < crossoverRate
             offspring[i], offspring[j] = crossover(population[selected[offidx[i]]], population[selected[offidx[j]]])
         else
@@ -80,7 +80,7 @@ function update_state!(objfun, constraints, state, population::AbstractVector{IT
     # Elitism (copy population individuals before they pass to the offspring & get mutated)
     fitidxs = sortperm(state.fitpop)
     for i in 1:state.eliteSize
-        subs = offspringSize+i
+        subs = offspringSize + i
         offspring[subs] = copy(population[fitidxs[i]])
     end
 

--- a/src/ga.jl
+++ b/src/ga.jl
@@ -22,10 +22,11 @@ struct GA{F1,F2,F3} <: AbstractOptimizer
 end
 
 GA(; populationSize::Int=50, crossoverRate::Float64=0.8, mutationRate::Float64=0.1,
-ɛ::Real=0, epsilon::Real=ɛ,
-selection::Function=((x,n) -> 1:n),
-crossover::Function=identity, mutation::Function=identity) =
-GA(populationSize, crossoverRate, mutationRate, epsilon, selection, crossover, mutation)
+    ɛ::Real=0, epsilon::Real=ɛ,
+    selection::Function=((x,n) -> 1:n),
+    crossover::Function=identity, mutation::Function=identity) =
+    GA(populationSize, crossoverRate, mutationRate, epsilon, selection, crossover, mutation)
+
 population_size(method::GA) = method.populationSize
 default_options(method::GA) = (iterations = 1000, abstol = 1e-15)
 summary(m::GA) = "GA[P=$(m.populationSize),x=$(m.crossoverRate),μ=$(m.mutationRate),ɛ=$(m.ɛ)]"


### PR DESCRIPTION
I noticed that the fields in the structs were abstract for functions, leading to type instability. This PR makes the functions concrete. The benchmark provided in the package showed a moderate improvement. Of course, this will vary depending on the details of the setup. 
Before:
```
            "ga" => Trial(510.096 μs)
            "cmaes" => Trial(82.302 ms)
            "es" => Trial(1.185 ms)
            "de" => Trial(1.030 ms)
```

After: 
```
            "ga" => Trial(400.469 μs)
            "cmaes" => Trial(85.420 ms)
            "es" => Trial(1.154 ms)
            "de" => Trial(750.362 μs)
```
Note that no changes were made to cmaes. 