### PR TITLE
Subset crossover

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ a
     - UX (uniform)
     - BINX (binary)
     - EXPX (exponential)
+    - BSX (binary subset)
   - real valued
     - DC (discrete)
     - AX (average)

--- a/docs/src/crossover.md
+++ b/docs/src/crossover.md
@@ -32,7 +32,7 @@ SHFX
 UX
 BINX
 EXPX
-SXO
+BSX
 ```
 
 Real-valued crossovers:

--- a/docs/src/crossover.md
+++ b/docs/src/crossover.md
@@ -32,6 +32,7 @@ TPX
 UX
 BINX
 EXPX
+SXO
 ```
 
 Real valued crossovers:
@@ -56,12 +57,6 @@ OX1
 CX
 OX2
 POS
-```
-
-Combinatorial crossovers:
-
-```@docs
-SXO
 ```
 
 Tree (expression) crossovers:

--- a/docs/src/crossover.md
+++ b/docs/src/crossover.md
@@ -58,6 +58,12 @@ OX2
 POS
 ```
 
+Combinatorial crossovers:
+
+```@docs
+SXO
+```
+
 Tree (expression) crossovers:
 
 ```@docs
@@ -77,3 +83,5 @@ Evolutionary.crosstree
 [^5]: K. Deep, K. P. Singh, M. L. Kansal, and C. Mohan, "A real coded  genetic algorithm for solving integer and mixed integer optimization problems.", Appl. Math. Comput. 212, 505-518, 2009
 
 [^6]: K. Deb, R. B. Agrawal, "Simulated Binary Crossover for Continuous Search Space", Complex Syst., 9., 1995
+
+[^7]: M. A. Wolters, “A Genetic Algorithm for Selection of Fixed-Size Subsets with Application to Design Problems”, J. Stat. Soft., vol. 68, no. 1, pp. 1–18, Nov. 2015.

--- a/src/Evolutionary.jl
+++ b/src/Evolutionary.jl
@@ -24,6 +24,7 @@ module Evolutionary
            SPX, TPX, UX,
            discrete, waverage, intermediate, line, HX, LX, MILX, SBX,
            PMX, OX1, CX, OX2, POS,
+           SXO,
            # GA selections
            ranklinear, uniformranking, roulette, rouletteinv, sus, susinv, tournament, truncation,
            # DE selections

--- a/src/Evolutionary.jl
+++ b/src/Evolutionary.jl
@@ -24,7 +24,7 @@ module Evolutionary
            SPX, TPX, UX, SHFX,
            DC, AX, WAX, IC, LC, HX, LX, MILX, SBX,
            PMX, OX1, CX, OX2, POS,
-           SXO,
+           BSX,
            # GA selections
            ranklinear, uniformranking, roulette, rouletteinv, sus, susinv,
            tournament, truncation,

--- a/src/recombinations.jl
+++ b/src/recombinations.jl
@@ -160,6 +160,26 @@ function EXPX(Cr::Real = 0.5)
     return expxvr
 end
 
+"""
+    SXO(k::Int)
+
+Subset crossover[^7]. Produces two offsprings by first pooling the unique items
+of the two parents, and then creating each offspring by sampling without 
+replacement at most `k` elements from the pool of items.
+"""
+function SXO(k::Int)
+    function SXO(v1::T, v2::T; rng::AbstractRNG=Random.GLOBAL_RNG) where {T <: AbstractVector{Bool}}
+        l = length(v1) # get number of available elements
+        pooled = findall(v1 .| v2) # pool parents selections
+        K = min(k,length(pooled)) # cannot sample more than the items in pool
+        c1 = falses(l) # init child 1
+        c2 = falses(l) # init child 2
+        c1[shuffle(rng, pooled)[1:K]] .= true # fill child 1 with sample from pool w/o replacement
+        c2[shuffle(rng, pooled)[1:K]] .= true # fill child 2 with sample from pool w/o replacement
+        return c1, c2
+    end
+    return SXO
+end
 
 # Real valued crossovers
 # ----------------------
@@ -481,27 +501,7 @@ function POS(v1::T, v2::T; rng::AbstractRNG=Random.GLOBAL_RNG) where {T <: Abstr
     return c1,c2
 end
 
-# Combinatorial crossovers
-# ----------------------
 
-"""
-    SXO(v1, v2)
-
-Subset crossover[^7]. Produces two offsprings by first pooling the unique items
-of the two parents, and then creating each offspring by sampling without
-replacement from the pool of items.
-"""
-function SXO(v1::T, v2::T; rng::AbstractRNG=Random.GLOBAL_RNG) where {T <: AbstractVector{Bool}}
-    l = length(v1) # get number of available elements
-    K = sum(v1) # get required subset size
-    @assert (sum(v2)==K) "v1 and v2 must have the same number of true entries"
-    pooled = findall(v1 .| v2) # pool parents selections
-    c1 = falses(l) # init child 1
-    c2 = falses(l) # init child 2
-    c1[shuffle(rng, pooled)[1:K]] .= true # fill child 1 with sample from pool w/o replacement
-    c2[shuffle(rng, pooled)[1:K]] .= true # fill child 2 with sample from pool w/o replacement
-    return c1, c2
-end
 
 # ===================
 # Genetic Programming

--- a/src/recombinations.jl
+++ b/src/recombinations.jl
@@ -481,6 +481,20 @@ function POS(v1::T, v2::T; rng::AbstractRNG=Random.GLOBAL_RNG) where {T <: Abstr
     return c1,c2
 end
 
+# Combinatorial crossovers
+# ----------------------
+
+function SXO(v1::T, v2::T; rng::AbstractRNG=Random.GLOBAL_RNG) where {T <: AbstractVector}
+    l = length(v1) # get number of available elements
+    K = sum(v1) # get required subset size
+    pooled = union(findall(v1),findall(v2)) # pool parents selections
+    c1 = falses(l) # init child 1
+    c2 = falses(l) # init child 2
+    c1[shuffle(pooled)[1:K]] .= true # fill child 1 with sample from pool w/o replacement
+    c2[shuffle(pooled)[1:K]] .= true # fill child 2 with sample from pool w/o replacement
+    return c1, c2
+end
+
 # ===================
 # Genetic Programming
 # ===================

--- a/src/recombinations.jl
+++ b/src/recombinations.jl
@@ -484,10 +484,17 @@ end
 # Combinatorial crossovers
 # ----------------------
 
-"""Subset crossover"""
-function SXO(v1::T, v2::T; rng::AbstractRNG=Random.GLOBAL_RNG) where {T <: AbstractVector}
+"""
+    SXO(v1, v2)
+
+Subset crossover[^7]. Produces two offsprings by first pooling the unique items
+of the two parents, and then creating each offspring by sampling without
+replacement from the pool of items.
+"""
+function SXO(v1::T, v2::T; rng::AbstractRNG=Random.GLOBAL_RNG) where {T <: AbstractVector{Bool}}
     l = length(v1) # get number of available elements
     K = sum(v1) # get required subset size
+    @assert (sum(v2)==K) "v1 and v2 must have the same number of true entries"
     pooled = findall(v1 .| v2) # pool parents selections
     c1 = falses(l) # init child 1
     c2 = falses(l) # init child 2

--- a/src/recombinations.jl
+++ b/src/recombinations.jl
@@ -491,8 +491,8 @@ function SXO(v1::T, v2::T; rng::AbstractRNG=Random.GLOBAL_RNG) where {T <: Abstr
     pooled = findall(v1 .| v2) # pool parents selections
     c1 = falses(l) # init child 1
     c2 = falses(l) # init child 2
-    c1[shuffle(pooled)[1:K]] .= true # fill child 1 with sample from pool w/o replacement
-    c2[shuffle(pooled)[1:K]] .= true # fill child 2 with sample from pool w/o replacement
+    c1[shuffle(rng, pooled)[1:K]] .= true # fill child 1 with sample from pool w/o replacement
+    c2[shuffle(rng, pooled)[1:K]] .= true # fill child 2 with sample from pool w/o replacement
     return c1, c2
 end
 

--- a/src/recombinations.jl
+++ b/src/recombinations.jl
@@ -484,6 +484,7 @@ end
 # Combinatorial crossovers
 # ----------------------
 
+"""Subset crossover"""
 function SXO(v1::T, v2::T; rng::AbstractRNG=Random.GLOBAL_RNG) where {T <: AbstractVector}
     l = length(v1) # get number of available elements
     K = sum(v1) # get required subset size

--- a/src/recombinations.jl
+++ b/src/recombinations.jl
@@ -488,7 +488,7 @@ end
 function SXO(v1::T, v2::T; rng::AbstractRNG=Random.GLOBAL_RNG) where {T <: AbstractVector}
     l = length(v1) # get number of available elements
     K = sum(v1) # get required subset size
-    pooled = union(findall(v1),findall(v2)) # pool parents selections
+    pooled = findall(v1 .| v2) # pool parents selections
     c1 = falses(l) # init child 1
     c2 = falses(l) # init child 2
     c1[shuffle(pooled)[1:K]] .= true # fill child 1 with sample from pool w/o replacement

--- a/src/recombinations.jl
+++ b/src/recombinations.jl
@@ -181,14 +181,14 @@ function EXPX(Cr::Real = 0.5)
 end
 
 """
-    SXO(k::Int)
+    BSX(k::Int)
 
-Subset crossover[^7]. Produces two offsprings by first pooling the unique items
-of the two parents, and then creating each offspring by sampling without 
+Binary Subset Crossover[^7]. Produces two offsprings by first pooling the unique
+items of the two parents, and then creating each offspring by sampling without 
 replacement at most `k` elements from the pool of items.
 """
-function SXO(k::Int)
-    function SXO(v1::T, v2::T; rng::AbstractRNG=Random.GLOBAL_RNG) where {T <: AbstractVector{Bool}}
+function BSX(k::Int)
+    function BSX(v1::T, v2::T; rng::AbstractRNG=Random.GLOBAL_RNG) where {T <: AbstractVector{Bool}}
         l = length(v1) # get number of available elements
         pooled = findall(v1 .| v2) # pool parents selections
         K = min(k,length(pooled)) # cannot sample more than the items in pool
@@ -198,7 +198,7 @@ function SXO(k::Int)
         c2[shuffle(rng, pooled)[1:K]] .= true # fill child 2 with sample from pool w/o replacement
         return c1, c2
     end
-    return SXO
+    return BSX
 end
 
 # Real valued crossovers

--- a/test/recombinations.jl
+++ b/test/recombinations.jl
@@ -52,6 +52,11 @@
         @test CX([8,4,7,3,6,2,5,1,9,0],collect(0:9)) == ([8,1,2,3,4,5,6,7,9,0],[0,4,7,3,6,2,5,1,8,9])
         @test SBX(0.0)(pop[1], pop[2]) == ([0.5, 0.5], [0.5, 0.5])
         @test sum(sum.(SBX()(pop[1], pop[2]) .- (pop[2], pop[1]))) ≈ 0 atol=1e-10
+        @test compare(
+            (SXO([true,false], [false,true]) for i in 1:100),
+            [ ([true,false], [true,false]), ([true,false], [false,true]),
+              ([false,true], [true,false]), ([false,true], [false,true]) ]
+        )
     end
 
     @testset "DE" begin

--- a/test/recombinations.jl
+++ b/test/recombinations.jl
@@ -53,7 +53,7 @@
         @test SBX(0.0)(pop[1], pop[2]) == ([0.5, 0.5], [0.5, 0.5])
         @test sum(sum.(SBX()(pop[1], pop[2]) .- (pop[2], pop[1]))) ≈ 0 atol=1e-10
         @test compare(
-            (SXO([true,false], [false,true]) for i in 1:100),
+            (SXO(1)([true,false], [false,true]) for i in 1:100),
             [ ([true,false], [true,false]), ([true,false], [false,true]),
               ([false,true], [true,false]), ([false,true], [false,true]) ]
         )

--- a/test/recombinations.jl
+++ b/test/recombinations.jl
@@ -52,12 +52,13 @@
         @test OX2([1:8;], [2,4,6,8,7,5,3,1], rng=rng) == ([1,2,3,4,6,5,7,8], [2,4,3,8,7,5,6,1])
         Random.seed!(rng, 18)
         @test POS([1:8;], [2,4,6,8,7,5,3,1], rng=rng) == ([1,4,6,2,3,5,7,8], [4,2,3,8,7,6,5,1])
-        Random.seed!(rng, 18)
-        @test compare(
-            (SXO(1)([true,false], [false,true], rng=rng) for i in 1:100),
-            [ ([true,false], [true,false]), ([true,false], [false,true]),
-              ([false,true], [true,false]), ([false,true], [false,true]) ]
-        )
+        
+        xo = SXO(3)                                                                 
+        @testset "BSX" for i in 1:100
+            off1, off2 = xo(Bool[1,0,1,0,1,0], Bool[1,1,1,1,0,0])
+            @test off1[end] == 0 && off2[end] == 0
+            @test sum(off1) == 3 && sum(off2) == 3
+        end
     end
 
     @testset "DE" begin

--- a/test/recombinations.jl
+++ b/test/recombinations.jl
@@ -53,7 +53,7 @@
         Random.seed!(rng, 18)
         @test POS([1:8;], [2,4,6,8,7,5,3,1], rng=rng) == ([1,4,6,2,3,5,7,8], [4,2,3,8,7,6,5,1])
         
-        xo = SXO(3)                                                                 
+        xo = BSX(3)                                                                 
         @testset "BSX" for i in 1:100
             off1, off2 = xo(Bool[1,0,1,0,1,0], Bool[1,1,1,1,0,0])
             @test off1[end] == 0 && off2[end] == 0


### PR DESCRIPTION
First of all, thank you all for such a great package! :clap: 

This PR introduces a recombination strategy suitable for working with problems that optimize over subsets of fixed size. In these problems, binary chromosomes of length L are used to encode a particular subset of size K of a set of L elements. The entries with 1's correspond to items selected.

With the current strategies, one is not guaranteed to obtain two children with the same number of selected elements as their parents. The "subset crossover" strategy introduced in this PR is adapted from [Wolters (2015)](https://www.jstatsoft.org/article/view/v068c01)---implemented in the [R package kofnGA](https://cran.r-project.org/web/packages/kofnGA/index.html)---and is guaranteed to produce children with the correct number of 1's.

Feel free to comment, modify, and/or suggest changes!