### PR TITLE
Fix small bugs/inconsistencies in GP

### DIFF
--- a/src/api/protected.jl
+++ b/src/api/protected.jl
@@ -1,7 +1,7 @@
 # Collection of protected function for GP
 
 """Protected division"""
-pdiv(x, y, undef=10e6) = ifelse(y==0 , x+undef  , div(x,y))
+pdiv(x, y, undef=10e6) = ifelse(y==0 , x+undef  , /(x,y))
 """Protected exponential"""
 pexp(x, undef=10e15)   = ifelse(x>=32, x+undef  , exp(x))
 """Protected natural log"""

--- a/src/gp.jl
+++ b/src/gp.jl
@@ -52,9 +52,12 @@ Returns a random terminal given the specification from the `TreeGP` object `t`.
 """
 function randterm(t::TreeGP)
     term = rand(keys(t.terminals))
-    if isa(term, Symbol)
+    if isa(term, Symbol) || isa(term, Real)
         term
+    elseif isa(term, Function)
+        term()
     else
+        # Code shouldn't reach branch but left as a catchall
         dim = t.terminals[term]
         dim == 1 ? rand() : rand(dim)
     end


### PR DESCRIPTION
I was messing around with GP to see how easy it would be to perform my work in Julia, and noticed a couple issues with the current implementation. 

First, the current protected division operator performs integer division - this has been changed to perform division using floats, which is more consistent with how the trees are generated by default. 

Second, given definition of a Terminal is Union{Symbol, Real, Function}, described as "symbols (variables), constant values, or 0-arity functions" However, the previous randterm method would only generate Symbols or would default to the rand() function. This has been changed to return the given Symbol or Real, or the results of the provided Function. This makes no changes to the default functionality (as the default terminals include rand), but allows for more user control over the generated Terminals