### PR TITLE
Expand `tournament`, `GA` docstrings

### DIFF
--- a/src/ga.jl
+++ b/src/ga.jl
@@ -6,7 +6,8 @@ The constructor takes following keyword arguments:
 - `populationSize`: The size of the population
 - `crossoverRate`: The fraction of the population at the next generation, not including elite children, that is created by the crossover function.
 - `mutationRate`: Probability of chromosome to be mutated
-- `ɛ`/`epsilon`: Positive integer specifies how many individuals in the current generation are guaranteed to survive to the next generation. Floating number specifies fraction of population.
+- `ɛ`/`epsilon`: Positive integer specifies how many individuals in the current generation are guaranteed to survive to the next generation.
+  Floating number specifies fraction of population. Elite individuals are still subject to mutation.
 - `selection`: [Selection](@ref) function (default: [`tournament`](@ref))
 - `crossover`: [Crossover](@ref) function (default: [`genop`](@ref))
 - `mutation`: [Mutation](@ref) function (default: [`genop`](@ref))
@@ -92,7 +93,7 @@ function update_state!(objfun, constraints, state, parents::AbstractVector{IT}, 
     minfit, fitidx = findmin(state.fitpop)
     state.fittest = offspring[fitidx]
     state.fitness = state.fitpop[fitidx]
-    
+
     # replace population
     parents .= offspring
 
@@ -119,7 +120,7 @@ function mutate!(population, method, constraints;
     for i in 1:n
         if rand(rng) < method.mutationRate
             method.mutation(population[i], rng=rng)
-        end        
+        end
         apply!(constraints, population[i])
     end
 end

--- a/src/selections.jl
+++ b/src/selections.jl
@@ -125,7 +125,12 @@ function truncation(fitness::Vector{<:Real}, N::Int; kwargs...)
     return idx[1:N]
 end
 
-"""Tournament selection"""
+"""
+    tournament(groupSize; select=argmin) → f(fitness, N)
+
+Create a [tournament-selection](https://en.wikipedia.org/wiki/Tournament_selection) function `f`
+for a given `groupSize`. `f` chooses the winner (as chosen by `select`) among `N` random groups.
+"""
 function tournament(groupSize::Int; select=argmin)
     @assert groupSize > 0 "Group size must be positive"
     function tournamentN(fitness::AbstractVecOrMat{<:Real}, N::Int;


### PR DESCRIPTION
In attempting to understand #106, I discovered that I could get better results by setting `ɛ = 0.1` in the `GA` constructor. Since I spent some time learning more about the internals of the package, I thought it might be useful to expand the docs in a couple of places.

AFAICT, "elite" individuals are subject to mutation, and I added that detail in my docstring. But is that wise? I have no expertise in these matters, but I wonder if one should be able to exactly retain the best individual yet found despite any other parameters of the algorithm. 