### PR TITLE
fix: some typos and grammar issues in typo-section of docs

### DIFF
--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -132,7 +132,7 @@ converged(::EvolutionaryOptimizationResults)
 
 ## Trace
 
-When `store_trace` and/or `show_trace` options are set to `true` in the [`Options`](@ref) object, an optimization trace is either captured and/or shown on the screen. By default, only the current state minimum value is displayed in the trace. In order to extend trace record, you need to override [`trace!`](@ref) function providing specialized function behavior on one of specific parameters.
+When `store_trace` and/or `show_trace` options are set to `true` in the [`Options`](@ref) object, an optimization trace is either captured and/or shown on the screen. By default, only the current state minimum value is displayed in the trace. In order to extend the trace record, you need to override the [`trace!`](@ref) function by providing specialized function behavior on one of specific parameters.
 
 ```@docs
 trace!(::Dict{String,Any}, Any, Any, Any, Any, Any)

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -132,7 +132,7 @@ converged(::EvolutionaryOptimizationResults)
 
 ## Trace
 
-When `store_trace` and/or `show_trace` options are set to `true` in the [`Options`](@ref) object, an optimization trace is either captured and/or shown on the screen. By default, only the current state minimum value is displayed in the trace. In order to extend trace record, you need to override [`trace!`](@ref) function providing specialize function behavior on one of specific parameters.
+When `store_trace` and/or `show_trace` options are set to `true` in the [`Options`](@ref) object, an optimization trace is either captured and/or shown on the screen. By default, only the current state minimum value is displayed in the trace. In order to extend trace record, you need to override [`trace!`](@ref) function providing specialized function behavior on one of specific parameters.
 
 ```@docs
 trace!(::Dict{String,Any}, Any, Any, Any, Any, Any)

--- a/src/api/objective.jl
+++ b/src/api/objective.jl
@@ -52,9 +52,13 @@ function value(obj::EvolutionaryObjective{TC,TF,TX,TP}, x::TX) where {TC,TF,TX,T
     obj.f(x)::TF
 end
 
-function value(obj::EvolutionaryObjective{TC,TF,TX,TP}, x::TX, pop::AbstractVector{TX}) where {TC,TF,TX,TP}
+function value(obj::EvolutionaryObjective{TC,TF,TX,TP}, x::TX, pop::AbstractVector{TX}, pop_dependent::Bool=false) where {TC,TF,TX,TP}
     obj.f_calls += 1
-    obj.f(x, pop)::TF
+    if pop_dependent
+        return obj.f(x, pop)::TF
+    else
+        obj.f(x)::TF
+    end
 end
 
 function value!(obj::EvolutionaryObjective{TC,TF,TX,TP}, x::TX) where {TC,TF,TX,TP}

--- a/src/api/objective.jl
+++ b/src/api/objective.jl
@@ -17,7 +17,7 @@ function EvolutionaryObjective(f::TC, x::AbstractArray,
                                F::Union{Real, AbstractArray{<:Real}} = 0;
                                eval::Symbol = :serial) where {TC}
     if F === 0
-        F = applicable(f, x) ? zero(f(x)) : 0
+        F = applicable(f, x) ? zero(f(x)) : convert(typeof(x), 0)
     end
     defval = default_values(x)
     # convert function into the in-place one

--- a/src/api/objective.jl
+++ b/src/api/objective.jl
@@ -98,7 +98,7 @@ end
 function value!(obj::EvolutionaryObjective{TC,TF,TX,Val{:serial}},
                 F::AbstractVector, xs::AbstractVector{TX}, pop_dependent::Bool=false) where {TC,TF<:Real,TX}
     if pop_dependent
-        broadcast!(x->value(obj,x,xs), F, xs, pop_dependent)
+        broadcast!(x->value(obj,x,xs, pop_dependent), F, xs)
     else
         broadcast!(x->value(obj,x), F, xs)
     end

--- a/src/api/objective.jl
+++ b/src/api/objective.jl
@@ -14,8 +14,11 @@ end
 Constructor for an objective function object around the function `f` with initial parameter `x`, and objective value `F`.
 """
 function EvolutionaryObjective(f::TC, x::AbstractArray,
-                               F::Union{Real, AbstractArray{<:Real}} = zero(f(x));
+                               F::Union{Real, AbstractArray{<:Real}} = missing;
                                eval::Symbol = :serial) where {TC}
+    if F === missing
+        F = applicable(f, x) ? zero(f(x)) : 0
+    end
     defval = default_values(x)
     # convert function into the in-place one
     TF = typeof(F)

--- a/src/api/objective.jl
+++ b/src/api/objective.jl
@@ -14,9 +14,9 @@ end
 Constructor for an objective function object around the function `f` with initial parameter `x`, and objective value `F`.
 """
 function EvolutionaryObjective(f::TC, x::AbstractArray,
-                               F::Union{Real, AbstractArray{<:Real}} = missing;
+                               F::Union{Real, AbstractArray{<:Real}} = 0;
                                eval::Symbol = :serial) where {TC}
-    if F === missing
+    if F === 0
         F = applicable(f, x) ? zero(f(x)) : 0
     end
     defval = default_values(x)

--- a/src/api/objective.jl
+++ b/src/api/objective.jl
@@ -98,7 +98,7 @@ end
 function value!(obj::EvolutionaryObjective{TC,TF,TX,Val{:serial}},
                 F::AbstractVector, xs::AbstractVector{TX}, pop_dependent::Bool=false) where {TC,TF<:Real,TX}
     if pop_dependent
-        broadcast!(x->value(obj,x,xs), F, xs)
+        broadcast!(x->value(obj,x,xs), F, xs, pop_dependent)
     else
         broadcast!(x->value(obj,x), F, xs)
     end
@@ -110,7 +110,7 @@ function value!(obj::EvolutionaryObjective{TC,TF,TX,Val{:thread}},
     n = length(xs)
     Threads.@threads for i in 1:n
         if pop_dependent
-            F[i] = value(obj, xs[i], xs)
+            F[i] = value(obj, xs[i], xs, pop_dependent)
         else
             F[i] = value(obj, xs[i])
         end
@@ -124,7 +124,7 @@ function value!(obj::EvolutionaryObjective{TC,TF,TX,Val{:serial}},
     for i in 1:n
         fv = view(F, :, i)
         if pop_dependent
-            value(obj, fv, xs[i], xs)
+            value(obj, fv, xs[i], xs, pop_dependent)
         else
             value(obj, fv, xs[i])
         end
@@ -139,7 +139,7 @@ function value!(obj::EvolutionaryObjective{TC,TF,TX,Val{:thread}},
         fv = view(F, :, i)
 
         if pop_dependent
-            value(obj, fv, xs[i], xs)
+            value(obj, fv, xs[i], xs, pop_dependent)
         else
             value(obj, fv, xs[i])
         end

--- a/src/api/objective.jl
+++ b/src/api/objective.jl
@@ -17,11 +17,11 @@ function EvolutionaryObjective(f::TC, x::AbstractArray,
                                F::Union{Real, AbstractArray{<:Real}} = 0;
                                eval::Symbol = :serial) where {TC}
     if F === 0
-        F = applicable(f, x) ? zero(f(x)) : convert(typeof(x), 0)
+        F = applicable(f, x) ? zero(f(x)) : 0
     end
     defval = default_values(x)
     # convert function into the in-place one
-    TF = typeof(F)
+    TF = F == 0 ? Float64 : typeof(F)
     fn, TN = if funargnum(f) == 2 && F isa AbstractArray
         ff = (Fv,xv) -> (Fv .= f(xv))
         ff, typeof(ff)

--- a/src/ga.jl
+++ b/src/ga.jl
@@ -18,20 +18,20 @@ struct GA{T1,T2,T3} <: AbstractOptimizer
     crossoverRate::Float64
     mutationRate::Float64
     ɛ::Real
+    pop_dependent::Bool
     selection::T1
     crossover::T2
     mutation::T3
     metrics::ConvergenceMetrics
-    pop_dependent::Bool
 
     GA(; populationSize::Int=50, crossoverRate::Float64=0.8, mutationRate::Float64=0.1,
         ɛ::Real=0, epsilon::Real=ɛ,
         selection::T1=tournament(2),
         crossover::T2=genop,
         mutation::T3=genop,
-        metrics = ConvergenceMetric[AbsDiff(1e-12)],
-        pop_dependent = false) where {T1, T2, T3} =
-        new{T1,T2,T3}(populationSize, crossoverRate, mutationRate, epsilon, selection, crossover, mutation, metrics)
+        pop_dependent::Bool=false,
+        metrics = ConvergenceMetric[AbsDiff(1e-12)]) where {T1, T2, T3} =
+        new{T1,T2,T3}(populationSize, crossoverRate, mutationRate, epsilon, pop_dependent, selection, crossover, mutation, metrics)
 end
 population_size(method::GA) = method.populationSize
 default_options(method::GA) = (iterations=1000,)

--- a/src/ga.jl
+++ b/src/ga.jl
@@ -90,7 +90,7 @@ function update_state!(objfun, constraints, state, parents::AbstractVector{IT}, 
     mutate!(offspring, method, constraints, rng=rng)
 
     # calculate fitness of the population
-    evaluate!(objfun, state.fitpop, offspring, constraints)
+    evaluate!(objfun, state.fitpop, offspring, constraints, method.pop_dependent)
 
     # select the best individual
     minfit, fitidx = findmin(state.fitpop)
@@ -128,9 +128,13 @@ function mutate!(population, method, constraints;
     end
 end
 
-function evaluate!(objfun, fitness, population, constraints)
+function evaluate!(objfun, fitness, population, constraints, pop_dependent=false)
     # calculate fitness of the population
-    value!(objfun, fitness, population)
+    if pop_dependent
+        value!(objfun, fitness, population, pop_dependent)
+    else
+        value!(objfun, fitness, population)
+    end
     # apply penalty to fitness
     penalty!(fitness, constraints, population)
 end


### PR DESCRIPTION
I was reading the documentation for optimization traces and noticed some minor issues in grammar. 