### PR TITLE
Typo fixes

### DIFF
--- a/docs/src/constraints.md
+++ b/docs/src/constraints.md
@@ -2,7 +2,7 @@
 using Evolutionary
 ```
 
-The nonlinear constrained optimization interface in `Evolutinary` assumes that the user can write the optimization problem as follows:
+The nonlinear constrained optimization interface in `Evolutionary` assumes that the user can write the optimization problem as follows:
 
 ```math
 \min_{x\in\mathbb{R}^n} f(x) \quad \text{such that}\\

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -132,7 +132,7 @@ converged(::EvolutionaryOptimizationResults)
 
 ## Trace
 
-When `store_trace` and/or `show_trace` options are set to `true` in the [`Options`](@ref) object, an optimization trace is either captured and/or shown on the screen. By default, only the current state minimum value is displayed in the trace. In order to extend trace record, you need to override [`trace!`](@ref) function providing specialize function behavior on one of specific parameters.
+When `store_trace` and/or `show_trace` options are set to `true` in the [`Options`](@ref) object, an optimization trace is either captured and/or shown on the screen. By default, only the current state minimum value is displayed in the trace. In order to extend the trace record, you need to override the [`trace!`](@ref) function by providing specialized function behavior on one of specific parameters.
 
 ```@docs
 trace!(::Dict{String,Any}, Any, Any, Any, Any, Any)

--- a/src/ga.jl
+++ b/src/ga.jl
@@ -6,7 +6,8 @@ The constructor takes following keyword arguments:
 - `populationSize`: The size of the population
 - `crossoverRate`: The fraction of the population at the next generation, not including elite children, that is created by the crossover function.
 - `mutationRate`: Probability of chromosome to be mutated
-- `ɛ`/`epsilon`: Positive integer specifies how many individuals in the current generation are guaranteed to survive to the next generation. Floating number specifies fraction of population.
+- `ɛ`/`epsilon`: Positive integer specifies how many individuals in the current generation are guaranteed to survive to the next generation.
+  Floating number specifies fraction of population. Elite individuals are still subject to mutation.
 - `selection`: [Selection](@ref) function (default: [`tournament`](@ref))
 - `crossover`: [Crossover](@ref) function (default: [`genop`](@ref))
 - `mutation`: [Mutation](@ref) function (default: [`genop`](@ref))
@@ -92,7 +93,7 @@ function update_state!(objfun, constraints, state, parents::AbstractVector{IT}, 
     minfit, fitidx = findmin(state.fitpop)
     state.fittest = offspring[fitidx]
     state.fitness = state.fitpop[fitidx]
-    
+
     # replace population
     parents .= offspring
 
@@ -119,7 +120,7 @@ function mutate!(population, method, constraints;
     for i in 1:n
         if rand(rng) < method.mutationRate
             method.mutation(population[i], rng=rng)
-        end        
+        end
         apply!(constraints, population[i])
     end
 end

--- a/src/gp.jl
+++ b/src/gp.jl
@@ -8,7 +8,7 @@ The constructor takes following keyword arguments:
 - `populationSize`: The size of the population
 - `terminals`: A dictionary of terminals with their their corresponding dimensionality
     - This dictionary contains (`Terminal`, `Int`) pairs
-    - The terminals can be any symbols (variables), constat values, or 0-arity functions.
+    - The terminals can be any symbols (variables), constant values, or 0-arity functions.
 - `functions`: A collection of functions with their corresponding arity.
     - This dictionary contains (`Function`, `Int`) pairs
 - `initialization`: A strategy for population initialization (default: `:grow`)

--- a/src/gp.jl
+++ b/src/gp.jl
@@ -18,9 +18,8 @@ The constructor takes following keyword arguments:
 - `mutation`: A mutation function (default: [`crosstree`](@ref))
 - `crossover`: A crossover function (default: [`subtree`](@ref))
 - `simplify`: An expression simplification function (default: `:nothing`)
-- `optimizer`: An evolutionary optimizer used for evolving the expressions (default: [`GA`](@ref))
-    - Use `mutation` and `crossover` parameters to specify GP-related mutation operation.
-    - Use `selection` parameter to specify the offspring selection procedure
+- Use `mutation` and `crossover` parameters to specify GP-related mutation operation.
+- Use `selection` parameter to specify the offspring selection procedure
 """
 @kwdef struct TreeGP <: AbstractOptimizer
     populationSize::Integer = 50

--- a/src/selections.jl
+++ b/src/selections.jl
@@ -125,7 +125,12 @@ function truncation(fitness::Vector{<:Real}, N::Int; kwargs...)
     return idx[1:N]
 end
 
-"""Tournament selection"""
+"""
+    tournament(groupSize; select=argmin) → f(fitness, N)
+
+Create a [tournament-selection](https://en.wikipedia.org/wiki/Tournament_selection) function `f`
+for a given `groupSize`. `f` chooses the winner (as chosen by `select`) among `N` random groups.
+"""
 function tournament(groupSize::Int; select=argmin)
     @assert groupSize > 0 "Group size must be positive"
     function tournamentN(fitness::AbstractVecOrMat{<:Real}, N::Int;


### PR DESCRIPTION
Did what @Nagefire suggested in #110  and combined all current open PRs regarding grammar and spelling in docs. This includes #101, #107, #108, #109, and #110. 