### PR TITLE
Fix piracy of `contains`

### DIFF
--- a/src/api/expressions.jl
+++ b/src/api/expressions.jl
@@ -95,7 +95,7 @@ function evaluate(ex::Expr, psyms::Dict{Symbol,Int}, vals::T...)::T where {T}
     try
         exprm[1](exvals...)
     catch err
-        @error "Incottect expression" ex psyms vals
+        @error "Incorrect expression" ex psyms vals
         rethrow(err)
     end
 end
@@ -270,7 +270,8 @@ function simplify!(root)
     return root
 end
 
-function Base.contains(ex::Expr, sym::Symbol)
+# This doesn't extend `Base.contains` because that would be piracy
+function contains(ex::Expr, sym::Symbol)
     for arg in ex.args
         issym(arg) && arg == sym && return true
         isa(arg, QuoteNode) && arg.value == sym && return true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,9 @@ using LinearAlgebra
 using Statistics
 using StableRNGs
 
+# Guard against accidental piracy from `import`
+@test Evolutionary.contains !== Base.contains
+
 for tests in [
     "types.jl",
     "objective.jl",


### PR DESCRIPTION
This defines a private `contains` function to avoid piracy of `Base.contains`. xref #117.