### PR TITLE
Add `Never <: ConvergenceMetric`

### DIFF
--- a/docs/src/convergence.md
+++ b/docs/src/convergence.md
@@ -21,6 +21,7 @@ calculations.
 Evolutionary.AbsDiff
 Evolutionary.RelDiff
 Evolutionary.GD
+Evolutionary.Never
 ```
 
 ## Auxiliary Functions

--- a/src/api/results.jl
+++ b/src/api/results.jl
@@ -138,7 +138,7 @@ function show(io::IO, r::EvolutionaryOptimizationResults)
             sgn = converged(cm) ? "≤" : "≰"
             dsc = description(cm)
             lpd = " "^(maxdsclen + 1 - length(dsc))
-            print(io, "$rpd$dsc$lpd= $(diff(cm)) $sgn $(tolerance(cm))\n" )
+            !isa(cm, Never) && print(io, "$rpd$dsc$lpd= $(diff(cm)) $sgn $(tolerance(cm))\n" )
         end
         print(io, "\n")
     end

--- a/src/api/termination.jl
+++ b/src/api/termination.jl
@@ -121,7 +121,7 @@ end
 GD(tol::T, inv=false) where {T<:AbstractFloat} = GD(tol, Inf, zeros(T,0,0), inv)
 GD(inv=false) = GD(1e-5, inv)
 function description(m::GD)
-    prefix = m.inverted ? "I" : "" 
+    prefix = m.inverted ? "I" : ""
     "|$(prefix)GD(P) - $(prefix)GD(P')|"
 end
 function assess!(m::GD, state::AbstractOptimizerState)
@@ -130,6 +130,16 @@ function assess!(m::GD, state::AbstractOptimizerState)
     m.value = val
     converged(m)
 end
+
+"""
+"Never converges" metric for single objective optimization.
+
+This allows one to force the optimization algorithm to run for a given number of iterations.
+"""
+mutable struct Never <: ConvergenceMetric
+end
+description(m::Never) = "never converges"
+assess!(m::Never, state::AbstractOptimizerState) = false
 
 
 """

--- a/src/api/termination.jl
+++ b/src/api/termination.jl
@@ -138,9 +138,9 @@ This allows one to force the optimization algorithm to run for a given number of
 """
 mutable struct Never <: ConvergenceMetric
 end
-description(m::Never) = "never converges"
+description(m::Never) = "never converges (fixed number of iterations)"
 assess!(m::Never, state::AbstractOptimizerState) = false
-
+converged(m::Never) = false
 
 """
     spread(S,R)


### PR DESCRIPTION
This is designed to make it easy to ensure that the algorithm always
performs the stated number of iterations. Because the various tolerance
options use `<=`, even setting them to 0 does not guarantee lack of
termination.