### PR TITLE
Update NLSolversBase to v8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]
-NLSolversBase = "^7.8"
+NLSolversBase = "8"
 StackViews = "^0.1"
 UnPack = "^1.0.1"
 julia = "^1.6"

--- a/src/api/constraints.jl
+++ b/src/api/constraints.jl
@@ -104,8 +104,14 @@ function show(io::IO,c::BoxConstraints)
     print(io, "Box Constraints:")
     indent = "    "
     cb = bounds(c)
-    NLSolversBase.showeq(io, indent, cb.eqx, cb.valx, 'x', :bracket)
-    NLSolversBase.showineq(io, indent, cb.ineqx, cb.σx, cb.bx, 'x', :bracket)
+    if !isempty(cb.eqx)
+        print(io, '\n', indent)
+        join(io, ("x[$i]=$v" for (i, v) in zip(cb.eqx, cb.valx)), ", ")
+    end
+    if !isempty(cb.ineqx)
+        print(io, '\n', indent)
+        join(io, ("x[$i]$(σ > 0 ? '≥' : '≤')$b" for (i, σ, b) in zip(cb.ineqx, cb.σx, cb.bx)), ", ")
+    end
 end
 
 """

--- a/src/api/objective.jl
+++ b/src/api/objective.jl
@@ -40,6 +40,8 @@ end
 
 f_calls(obj::EvolutionaryObjective) = obj.f_calls
 
+value(obj::EvolutionaryObjective) = obj.F
+
 """
     ismultiobjective(objfun)
 


### PR DESCRIPTION
## Summary

Updates Evolutionary to be compatible with [NLSolversBase v8.0.0](https://github.com/JuliaNLSolvers/NLSolversBase.jl/releases/tag/v8.0.0).

Three changes were required:

- **Compat bump:** `NLSolversBase = "^7.8"` → `"8"`.
- **Restore `value(::EvolutionaryObjective)` no-arg method.** v8 narrowed `value(::AbstractObjective) = obj.F` (NLSolversBase#163) to only the built-in concrete types, so every `AbstractObjective` subtype loses the inherited fallback. Without this fix `value(objfun)` calls in `ga.jl`, `es.jl`, `nsga2.jl`, `optimize.jl` and `utilities.jl` would error at runtime.
- **Inline `BoxConstraints` show formatting.** The previous code called the non-public `NLSolversBase.showeq` / `showineq` helpers, whose 6th argument changed from `Symbol` (`:bracket`/`:subscript`) to `Bool` in v8. Inlining the small format loop removes the dependency on internal API.

## Test plan

- [x] Local `Pkg.test()` against the dev'd NLSolversBase v8.0.0
- [x] Smoke test of `value!`, `value(obj)`, and `BoxConstraints` rendering (incl. mixed eq + ineq bounds)
- [x] Diff vs master: identical test results — 10 pre-existing GP "Point Mutation" failures (unrelated to this change, present on master with NLSolversBase v7 under Julia 1.12 as well), everything else green
- [ ] Wait for CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)