### PR TITLE
Drop brittle == 7 in Point Mutation test for Julia 1.11+ compat

### DIFF
--- a/test/mutations.jl
+++ b/test/mutations.jl
@@ -124,11 +124,15 @@
         end
 
         # point
+        # The invariant is length(ex) == length(mex); the original `== 7` was the
+        # length on Julia 1.10 only. Julia 1.11 changed how `rand` samples from
+        # `Dict`/`KeySet`, so `rand(rng, tr, H)` yields a different tree on 1.11+
+        # even under StableRNG.
         mut = point(tr)
         Random.seed!(rng, 1)
         @testset "Point Mutation" for i in 1:10
             mex = mut(copy(ex), rng=rng)
-            @test length(ex) == length(mex) == 7
+            @test length(ex) == length(mex)
             @test sum(x == y for (x,y) in zip(ex.args, mex.args)) >= 2
         end
 


### PR DESCRIPTION
## Summary

Please ignore this PR until reviewed by @ChrisRackauckas.

Fixes the 10 pre-existing `Point Mutation` test failures on Julia 1.11+ (visible in any recent CI run on master where the matrix includes Julia 1.x — and called out in #133).

## Root cause

The test in `test/mutations.jl` asserts:

```julia
@test length(ex) == length(mex) == 7
```

The `== 7` was the tree length produced by `rand(rng, tr, 2)` on Julia 1.10. Julia 1.11 reimplemented `rand(::AbstractRNG, ::Dict/Set/KeySet)` with a more efficient algorithm that consumes the RNG stream differently. `Evolutionary.rand(rng, ::TreeGP, H)` in `src/gp.jl` calls `rand(rng, keys(t.terminals))` / `rand(rng, keys(t.functions))` — i.e. `rand` over a `KeySet`. On Julia 1.11+ that produces a different (length-5) tree even with `StableRNG(42)`, because `StableRNGs` stabilizes the raw RNG number stream, not how `Base`'s collection sampling consumes it.

The behavioral invariant being tested is that point mutation preserves the node count of the input expression. `length(ex) == length(mex)` already captures that; the `== 7` was hard-coding an implementation artifact specific to 1.10's `Dict`-sampling RNG sequence.

## Change

One-line test change plus a 4-line comment explaining the WHY (so a future reader doesn't re-add the constant):

```diff
+        # The invariant is length(ex) == length(mex); the original `== 7` was the
+        # length on Julia 1.10 only. Julia 1.11 changed how `rand` samples from
+        # `Dict`/`KeySet`, so `rand(rng, tr, H)` yields a different tree on 1.11+
+        # even under StableRNG.
-            @test length(ex) == length(mex) == 7
+            @test length(ex) == length(mex)
```

No source code changes — this is a brittle test, not a bug.

## Test plan

- [x] Local `Pkg.test()` on Julia **1.10.11** (was already passing) — still passes.
- [x] Local `Pkg.test()` on Julia **1.12.6** (was failing with 10 Point Mutation failures) — now passes.
- [ ] CI on this PR.

## Context

Discovered while modernizing CI infrastructure in #134 (which expanded the test matrix to include `pre`/`1`/`lts` on multiple OSes and surfaced these failures consistently). This fix is split out as its own PR because it's a test correctness change, separate from CI-infra work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)