### PR TITLE
Centralize CI on SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,11 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"
+      - "/docs"
+      - "/examples"
     schedule:
       interval: "daily"
     groups:

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -9,18 +9,5 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      statuses: write
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: julia-actions/cache@v3
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-docdeploy@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
+    uses: "SciML/.github/.github/workflows/documentation.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -12,21 +12,8 @@ on:
       - 'docs/**'
 jobs:
   test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        continue-on-error: true
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      skip: "Pkg,TOML"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,5 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,5 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.0
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"

--- a/src/api/constraints.jl
+++ b/src/api/constraints.jl
@@ -75,7 +75,7 @@ isfeasible(c::AbstractConstraints, x) = isfeasible(c.bounds, x, value(c, x))
 
 # Implementations
 
-"""Type for an empty set of constratins"""
+"""Type for an empty set of constraints"""
 struct NoConstraints <: AbstractConstraints end
 isfeasible(c::NoConstraints, x) = true
 getproperty(c::NoConstraints, s::Symbol) =


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Converts all CI to the centralized SciML reusable workflows (pinned `@v1`, every caller has `secrets: "inherit"`).

## Converted (inline -> central caller)
- **Documentation.yml** -> `documentation.yml@v1` (was inline `julia-docdeploy`; coverage default true preserved)
- **Downgrade.yml** -> `downgrade.yml@v1` (preserved `julia-version: 1.10`, `skip: Pkg,TOML`, allow-reresolve false)
- **FormatCheck.yml** (Runic) -> `runic.yml@v1` (was inline `fredrikekre/runic-action`)
- **SpellCheck.yml** -> `spellcheck.yml@v1` (was inline `crate-ci/typos`)

## Already central
- **Tests.yml** already called `tests.yml@v1`; left intact (matrix unchanged), `secrets: inherit` confirmed.

## Added
- None new — all relevant checks already existed; just centralized.

## Typos
- 1 fixed: `constratins` -> `constraints` (docstring in `src/api/constraints.jl`). `typos .` now exits 0.

## Runic
- No formatting changes (repo was already Runic-clean).

## Dependabot
- Removed the `crate-ci/typos` ignore (no longer pinned inline).
- Extended the `julia` ecosystem block to cover `/docs` and `/examples` (both have a `Project.toml`), kept `/`, daily, group all-julia-packages `["*"]`.

## Note on branch protection
Check names change (e.g. the Runic job is now `Runic Format Check`, Downgrade is `Downgrade Tests`, SpellCheck is `Spell Check with Typos`, docs build via the reusable workflow). **Required-status-check names in branch protection will need updating** to match the new job names.

`name:`/`on:`/`concurrency:` blocks on each workflow file were preserved. No CompatHelper.yml existed; TagBot.yml unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)