### PR TITLE
Use SciMLTesting v1.2 (folder-based run_tests)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,8 +13,9 @@ UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 [compat]
 LinearAlgebra = "1"
 NLSolversBase = "8"
-Pkg = "1"
 Random = "1"
+SafeTestsets = "0.0.1, 0.1"
+SciMLTesting = "1"
 StableRNGs = "1"
 StackViews = "^0.1"
 Statistics = "1"
@@ -23,9 +24,10 @@ UnPack = "^1.0.1"
 julia = "1.10"
 
 [extras]
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "StableRNGs", "Pkg"]
+test = ["Test", "StableRNGs", "SafeTestsets", "SciMLTesting"]

--- a/test/gp.jl
+++ b/test/gp.jl
@@ -1,3 +1,8 @@
+using Evolutionary
+using Test
+using Random
+using StableRNGs
+
 @testset "Genetic Programming" begin
     rng = StableRNG(42)
 

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -1,3 +1,7 @@
+using Evolutionary
+using Test
+include("types.jl")
+
 @testset "API" begin
 
     #########

--- a/test/knapsack.jl
+++ b/test/knapsack.jl
@@ -1,3 +1,8 @@
+using Evolutionary
+using Test
+using Random
+using StableRNGs
+
 @testset "Knapsack" begin
     rng = StableRNG(42)
 

--- a/test/moea.jl
+++ b/test/moea.jl
@@ -1,3 +1,8 @@
+using Evolutionary
+using Test
+using Random
+using StableRNGs
+
 @testset "Multi-objective EA" begin
 
     rng = StableRNG(42)

--- a/test/mutations.jl
+++ b/test/mutations.jl
@@ -1,3 +1,8 @@
+using Evolutionary
+using Test
+using Random
+using StableRNGs
+
 @testset "Mutations" begin
 
     rng = StableRNG(42)

--- a/test/n-queens.jl
+++ b/test/n-queens.jl
@@ -1,3 +1,8 @@
+using Evolutionary
+using Test
+using Random
+using StableRNGs
+
 @testset "n-Queens" begin
     rng = StableRNG(42)
 

--- a/test/objective.jl
+++ b/test/objective.jl
@@ -1,3 +1,6 @@
+using Evolutionary
+using Test
+
 @testset "Evolutionary Objective" begin
 
     v = Evolutionary.default_values(ones(3))

--- a/test/onemax.jl
+++ b/test/onemax.jl
@@ -1,3 +1,8 @@
+using Evolutionary
+using Test
+using Random
+using StableRNGs
+
 @testset "OneMax" begin
 
     rng = StableRNG(42)

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -2,7 +2,8 @@
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Evolutionary = "86b6b26d-c046-49b6-aa0b-5f0f74682bd6"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
@@ -11,5 +12,7 @@ Evolutionary = {path = "../.."}
 [compat]
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"
+SafeTestsets = "0.0.1, 0.1"
+SciMLTesting = "1"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,8 +1,3 @@
-using Pkg
-Pkg.activate(@__DIR__)
-Pkg.develop(PackageSpec(path = joinpath(@__DIR__, "..", "..")))
-Pkg.instantiate()
-
 using Evolutionary
 using Aqua
 using JET

--- a/test/rastrigin.jl
+++ b/test/rastrigin.jl
@@ -1,3 +1,8 @@
+using Evolutionary
+using Test
+using Random
+using StableRNGs
+
 @testset "Rastrigin" begin
 
     rng = StableRNG(42)

--- a/test/recombinations.jl
+++ b/test/recombinations.jl
@@ -1,3 +1,8 @@
+using Evolutionary
+using Test
+using Random
+using StableRNGs
+
 @testset "Recombinations" begin
 
     rng = StableRNG(42)

--- a/test/regression.jl
+++ b/test/regression.jl
@@ -1,3 +1,9 @@
+using Evolutionary
+using Test
+using Random
+using LinearAlgebra
+using StableRNGs
+
 @testset "Regression" begin
 
     rng = StableRNG(42)

--- a/test/rosenbrock.jl
+++ b/test/rosenbrock.jl
@@ -1,3 +1,8 @@
+using Evolutionary
+using Test
+using Random
+using StableRNGs
+
 @testset "Rosenbrock" begin
 
     rng = StableRNG(42)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,40 +1,39 @@
-using Evolutionary
+using SafeTestsets
 using Test
-using Random
-using LinearAlgebra
-using Statistics
-using StableRNGs
+using SciMLTesting
 
-const GROUP = get(ENV, "GROUP", "All")
-
-# Any group other than "QA" runs the full functional suite (the matrix splits
-# Core across version/OS cells only; the suite itself is the same).
-if GROUP != "QA"
-    # Guard against accidental piracy from `import`
-    @test Evolutionary.contains !== Base.contains
-
-    for tests in [
-            "types.jl",
-            "objective.jl",
-            "interface.jl",
-            "selections.jl",
-            "recombinations.jl",
-            "mutations.jl",
-            "sphere.jl",
-            "rosenbrock.jl",
-            "schwefel.jl",
-            "rastrigin.jl",
-            "n-queens.jl",
-            "knapsack.jl",
-            "onemax.jl",
-            "moea.jl",
-            "regression.jl",
-            "gp.jl",
-        ]
-        include(tests)
+# The functional suite is identical across the Core and CoreLTSPre groups; those
+# groups exist only to split the version/OS matrix (see test/test_groups.toml).
+# Both run the same set of files, so they share one body thunk; `all = ["Core"]`
+# keeps the local default (GROUP unset => "All") running the suite exactly once.
+function functional_suite()
+    @safetestset "Piracy guard" begin
+        using Evolutionary
+        # Guard against accidental piracy from `import`
+        @test Evolutionary.contains !== Base.contains
     end
+    @safetestset "Types" include("types.jl")
+    @safetestset "Evolutionary Objective" include("objective.jl")
+    @safetestset "API" include("interface.jl")
+    @safetestset "Selections" include("selections.jl")
+    @safetestset "Recombinations" include("recombinations.jl")
+    @safetestset "Mutations" include("mutations.jl")
+    @safetestset "Sphere" include("sphere.jl")
+    @safetestset "Rosenbrock" include("rosenbrock.jl")
+    @safetestset "Schwefel CMA-ES" include("schwefel.jl")
+    @safetestset "Rastrigin" include("rastrigin.jl")
+    @safetestset "n-Queens" include("n-queens.jl")
+    @safetestset "Knapsack" include("knapsack.jl")
+    @safetestset "OneMax" include("onemax.jl")
+    @safetestset "Multi-objective EA" include("moea.jl")
+    @safetestset "Regression" include("regression.jl")
+    @safetestset "Genetic Programming" include("gp.jl")
+    return nothing
 end
 
-if GROUP == "QA"
-    include(joinpath(@__DIR__, "qa", "qa.jl"))
-end
+run_tests(;
+    core = functional_suite,
+    groups = Dict("CoreLTSPre" => functional_suite),
+    qa = (; env = joinpath(@__DIR__, "qa"), body = joinpath(@__DIR__, "qa", "qa.jl")),
+    all = ["Core"],
+)

--- a/test/schwefel.jl
+++ b/test/schwefel.jl
@@ -1,3 +1,8 @@
+using Evolutionary
+using Test
+using Random
+using StableRNGs
+
 @testset "Schwefel CMA-ES" begin
 
     rng = StableRNG(42)

--- a/test/selections.jl
+++ b/test/selections.jl
@@ -1,3 +1,9 @@
+using Evolutionary
+using Test
+using Random
+using Statistics
+using StableRNGs
+
 @testset "Selections" begin
 
     rng = StableRNG(42)

--- a/test/sphere.jl
+++ b/test/sphere.jl
@@ -1,3 +1,8 @@
+using Evolutionary
+using Test
+using Random
+using StableRNGs
+
 @testset "Sphere" begin
 
     rng = StableRNG(42)

--- a/test/types.jl
+++ b/test/types.jl
@@ -1,3 +1,5 @@
+using Evolutionary
+using Test
 import Evolutionary: value, population_size, default_options, minimizer,
     initial_state, update_state!
 


### PR DESCRIPTION
Converts `test/runtests.jl` to the **SciMLTesting v1.2** harness.

### Shape
Multi-group single package. `test/test_groups.toml` declares `Core`, `CoreLTSPre`, and `QA`. The `Core` and `CoreLTSPre` groups run the **identical** functional suite — they exist only to split the version/OS CI matrix. This shared-file-set-across-two-groups shape cannot be expressed by SciMLTesting's bare folder-discovery mode (which would require duplicating the 16 files into a `test/CoreLTSPre/` folder and would double-run the suite under the local `All` default), so this uses the v1.2 **explicit-args** form (still v1.2, the backward-compatible `run_tests(; core, groups, qa, all)` path) over a clean folder layout.

### Layout
- **Core** = top-level `test/*.jl` (the 16 functional files), each now a self-contained `@safetestset` body that brings its own `using`s.
- **CoreLTSPre** shares the same body thunk as Core.
- **QA** = `test/qa/` with its own `test/qa/Project.toml` sub-env (Aqua + JET), activated by the harness.
- `all = ["Core"]` keeps `GROUP` unset (local default `"All"`) running the functional suite exactly once.

### Behavior preservation
The exact set of tests run under each `GROUP` value is unchanged from master:
- `GROUP=Core`, `GROUP=CoreLTSPre`, and the local `All` default → the 16-file functional suite + the piracy guard, once.
- `GROUP=QA` → `qa.jl` (Aqua + the 4 tracked `@test_broken` markers).

Verified locally on Julia 1.11: `GROUP=Core` → `Testing Evolutionary tests passed`; `GROUP=QA` → `QA | 8 Pass, 4 Broken` → `Testing Evolutionary tests passed`. `test/test_groups.toml` is unchanged.

### Deps
- Root `Project.toml`: added `SciMLTesting` + `SafeTestsets` (+ compat) to `[extras]`/`[targets].test`/`[compat]`; dropped `Pkg` (the harness owns env activation; no `test/*.jl` uses `Pkg` anymore).
- `test/qa/Project.toml`: added `SciMLTesting` + `SafeTestsets`; dropped `Pkg`.

Ignore until reviewed by @ChrisRackauckas.
