### PR TITLE
Fix docs-deploy: add permissions block to Documentation caller job

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -9,5 +9,9 @@ on:
 
 jobs:
   build:
+    permissions:
+      actions: write
+      contents: write
+      statuses: write
     uses: "SciML/.github/.github/workflows/documentation.yml@v1"
     secrets: "inherit"


### PR DESCRIPTION
## Problem

The docs **build** passes, but the `deploydocs` push to `gh-pages` fails (403 / GITHUB_TOKEN cannot push).

## Root cause

The CI-centralization migration (centralizing on the SciML reusable [`documentation.yml@v1`](https://github.com/SciML/.github/blob/v1/.github/workflows/documentation.yml)) dropped the `permissions:` block from the `.github/workflows/Documentation.yml` caller job.

The reusable workflow declares **no permissions of its own** and deploys via:

```yaml
GITHUB_TOKEN: ${{ inputs.github-token || secrets.GITHUB_TOKEN }}
DOCUMENTER_KEY: ${{ inputs.documenter-key || secrets.DOCUMENTER_KEY }}
```

Because the reusable declares no `permissions:`, the **caller job's** permissions flow through to the `GITHUB_TOKEN`. With no block on the caller, the token is read-only, so Documenter's `deploydocs` cannot push to `gh-pages`.

## Fix

Add a `permissions:` block to the caller job:

```yaml
jobs:
  build:
    permissions:
      actions: write
      contents: write
      statuses: write
    uses: "SciML/.github/.github/workflows/documentation.yml@v1"
    secrets: "inherit"
```

This mirrors the proven fix in SciML/OrdinaryDiffEqOperatorSplitting.jl#90 exactly.

This repo deploys via GITHUB_TOKEN (no DOCUMENTER_KEY required), so `contents: write` is what enables the gh-pages push. The docs check is **not** disabled and `warnonly` is **not** set.

## Verification

- YAML validated with `python3 -c "yaml.safe_load(...)"` — parses cleanly; the `build.permissions` block resolves to `{actions: write, contents: write, statuses: write}`.
- The actual gh-pages deploy can only be fully confirmed by a real CI run on `master` (deploydocs only pushes on `push` events, not PRs). The change is correct by construction by matching the proven #90 pattern.

Please ignore until reviewed by @ChrisRackauckas.