### PR TITLE
QA: run_qa v1.6 form + ExplicitImports

### DIFF
--- a/src/Evolutionary.jl
+++ b/src/Evolutionary.jl
@@ -1,8 +1,9 @@
 module Evolutionary
-using LinearAlgebra, Statistics
+using LinearAlgebra: Diagonal, Symmetric, diag, diagm, eigen!, norm
+using Statistics: mean
 using Base: @kwdef
 using UnPack: @unpack
-using StackViews
+using StackViews: StackView
 using Random: AbstractRNG, default_rng, randperm, shuffle, randn!
 using NLSolversBase: NLSolversBase, AbstractObjective, ConstraintBounds,
     AbstractConstraints, nconstraints_x, nconstraints

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,8 +1,5 @@
 [deps]
-Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Evolutionary = "86b6b26d-c046-49b6-aa0b-5f0f74682bd6"
-JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
-SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
@@ -10,9 +7,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Evolutionary = {path = "../.."}
 
 [compat]
-Aqua = "0.8"
-JET = "0.9,0.10,0.11"
-SafeTestsets = "0.0.1, 0.1"
-SciMLTesting = "1"
+SciMLTesting = "1.6"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,27 +1,32 @@
-using Evolutionary
-using Aqua
-using JET
-using Test
+using SciMLTesting, Evolutionary, Test
 
-@testset "Quality Assurance" begin
-    @testset "Aqua" begin
-        # ambiguities, unbound_args and piracies currently fail; keep the
-        # other Aqua sub-checks running and mark the failing ones broken.
-        # Tracked in https://github.com/SciML/Evolutionary.jl/issues/145
-        Aqua.test_all(
-            Evolutionary;
-            ambiguities = false,
-            unbound_args = false,
-            piracies = false,
-        )
-        @test_broken false  # Aqua ambiguities: 18 found in optimize overloads (src/api/optimize.jl) — tracked in https://github.com/SciML/Evolutionary.jl/issues/145
-        @test_broken false  # Aqua unbound_args: 3 methods (src/api/expressions.jl) — tracked in https://github.com/SciML/Evolutionary.jl/issues/145
-        @test_broken false  # Aqua piracies: 7 methods (Expr ops, replace, value) — tracked in https://github.com/SciML/Evolutionary.jl/issues/145
-    end
-    @testset "JET" begin
-        # JET.test_package reports errors (e.g. +(::Nothing,::Int) and kwcall
-        # on deprecated crossover/mutation aliases in src/deprecated.jl).
-        # Tracked in https://github.com/SciML/Evolutionary.jl/issues/145
-        @test_broken false  # JET: report_package errors — tracked in https://github.com/SciML/Evolutionary.jl/issues/145
-    end
+run_qa(
+    Evolutionary;
+    explicit_imports = true,
+    # ambiguities, unbound_args and piracies still fail; keep them disabled and
+    # tracked. https://github.com/SciML/Evolutionary.jl/issues/145
+    aqua_broken = (
+        :ambiguities,    # 18 ambiguities in optimize overloads (src/api/optimize.jl)
+        :unbound_args,   # 3 methods (src/api/expressions.jl)
+        :piracies,       # 7 methods (Expr ops, replace, value)
+    ),
+    ei_kwargs = (;
+        # other packages' non-public names: ignore until they go public upstream.
+        all_explicit_imports_are_public = (;
+            ignore = (
+                :default_rng,     # Random (stdlib non-public)
+                :nconstraints,    # NLSolversBase non-public
+                :nconstraints_x,  # NLSolversBase non-public
+            ),
+        ),
+    ),
+)
+
+# JET surfaces method/typo errors only on Julia >= 1.12 (the QA `1` lane), while the
+# LTS lane is clean, so neither a hard JET check (fails 1.12) nor `jet_broken = true`
+# (auto-flags an Unexpected Pass on the clean LTS lane) is correct across the matrix.
+# Keep the finding tracked as a static broken placeholder.
+# https://github.com/SciML/Evolutionary.jl/issues/145
+@testset "JET" begin
+    @test_broken false  # report_package: +(::Nothing,::Int), kwcall on SPX, Evolutionary.expr (Julia >= 1.12)
 end


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.**

Brings Evolutionary.jl's QA onto the SciMLTesting 1.6 `run_qa` form with ExplicitImports enabled. Verified locally against the **released** SciMLTesting 1.6.0 (Pkg resolves it; no dev-from-branch).

## What changed
- `test/qa/qa.jl`: hand-rolled `Aqua.test_all` + JET body → `run_qa(Evolutionary; explicit_imports = true, ...)`.
- `test/qa/Project.toml`: drop `Aqua`/`JET`/`SafeTestsets` (now transitive via SciMLTesting); bump `SciMLTesting` compat floor to `1.6`.
- `src/Evolutionary.jl`: make the implicit `LinearAlgebra`/`Statistics`/`StackViews` imports explicit (the `no_implicit_imports` fix).

## ExplicitImports findings (6 checks)
- **no_implicit_imports** — FIXED. Converted `using LinearAlgebra, Statistics` + `using StackViews` to `using LinearAlgebra: Diagonal, Symmetric, diag, diagm, eigen!, norm`, `using Statistics: mean`, `using StackViews: StackView`. The names `rank`/`tr`/`var` that EI also reported are shadowed by local bindings (a nested `function rank`, a `tr` function parameter, a `var` tuple-unpack local), not genuine uses of `LinearAlgebra.rank`/`tr`/`Statistics.var`, so they are intentionally **not** imported. Core functional suite re-run green to confirm no runtime breakage.
- **no_stale_explicit_imports** — passes.
- **all_explicit_imports_via_owners / all_qualified_accesses_via_owners / all_qualified_accesses_are_public** — pass.
- **all_explicit_imports_are_public** — IGNORE the three other-package non-public names via `ei_kwargs` (they go public as the base libs declare them):
  - `default_rng` (Random, stdlib non-public)
  - `nconstraints`, `nconstraints_x` (NLSolversBase non-public)

## Preserved tracked-broken findings (issue #145)
- **Aqua** `ambiguities` (18), `unbound_args` (3), `piracies` (7) → `aqua_broken` (tracked, #145).
- **JET** → kept as a static `@test_broken` placeholder rather than `jet_broken = true`. The JET report findings (`+(::Nothing,::Int)`, `kwcall` on `SPX`/deprecated aliases, `Evolutionary.expr`) surface **only on Julia >= 1.12** (the QA `1` lane); the LTS lane (1.10/1.11) is clean. `jet_broken = true` would auto-flag an Unexpected-Pass Error on the clean LTS lane, and a hard JET check would fail the `1` lane — so a static tracked placeholder is the only form correct across the `["lts", "1"]` matrix. Tracked in #145.

## Local verification (released SciMLTesting 1.6.0)
QA group via `GROUP=QA Pkg.test`, both lanes:

| Julia | Pass | Broken | Fail | Error |
|------|------|--------|------|-------|
| 1.10 (lts) | 14 | 4 | 0 | 0 |
| 1.12 (`1`) | 14 | 4 | 0 | 0 |

Aqua enabled sub-checks (8 pass): undefined exports, project-extras, stale deps, compat bounds (4), persistent tasks. ExplicitImports: 6 pass. The 4 broken = 3 Aqua placeholders + 1 JET placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
