### PR TITLE
Bump version to 0.11.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Evolutionary"
 uuid = "86b6b26d-c046-49b6-aa0b-5f0f74682bd6"
-version = "0.11.3"
+version = "0.11.4"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
Automated patch version bump (0.11.3 -> 0.11.4) to release unreleased commits on `master` via JuliaRegistrator.