### PR TITLE
Release prep: bump Evolutionary to 0.11.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Evolutionary"
 uuid = "86b6b26d-c046-49b6-aa0b-5f0f74682bd6"
-version = "0.11.4"
+version = "0.11.5"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
Patch release for the accumulated docstring/QA/test-scaffolding changes since 0.11.4 (no functional/API changes).