### PR TITLE
Remove redundant QA self source

### DIFF
--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -3,9 +3,6 @@ Evolutionary = "86b6b26d-c046-49b6-aa0b-5f0f74682bd6"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-Evolutionary = {path = "../.."}
-
 [compat]
 SciMLTesting = "2.1"
 Test = "1"


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary
- Remove the redundant package-under-test `[sources]` path entry from `test/qa/Project.toml`.
- Keep the SciMLTesting 2.1 QA setup unchanged.

## Validation
- `timeout 3600 /home/crackauc/.juliaup/bin/julia --project=@runic -e 'using Runic; exit(Runic.main(ARGS))' -- --check test/qa/Project.toml`\n- `GROUP=QA timeout 3600 /home/crackauc/.juliaup/bin/julia --project=. -e 'using Pkg; Pkg.test()'`