### PR TITLE
Release prep: bump version to 0.11.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Evolutionary"
 uuid = "86b6b26d-c046-49b6-aa0b-5f0f74682bd6"
-version = "0.11.5"
+version = "0.11.6"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
## Summary

Bumps the package version from 0.11.5 to 0.11.6 to register the one unreleased commit sitting on top of the last registered version.

The last registered version (0.11.5, git-tree-sha1 `964ebe5ec5717e98a3605a8f01dc1643cb9d8670`) corresponds to commit 7c90bbe ("Bump Evolutionary to 0.11.5 for release (#154)"). Since then, one additional commit has landed on master:

- 9d18c44 "Remove redundant QA self source (#155)" — removes a `[sources]` override block from `test/qa/Project.toml` (test-infra only, no source/API changes).

## Bump type: PATCH (0.11.5 -> 0.11.6)

The only change since the last release touches `test/qa/Project.toml` (a test-tooling manifest), not any package source file. There is no new public API, no behavior change, and no breaking change — this is a test/CI-infrastructure-only diff, so a PATCH bump is appropriate.

## Compat bounds

No changes to `[compat]` bounds were needed. The package has no non-test dependency on SciML-ecosystem packages (SciMLBase, DiffEqBase, etc.); the only SciML-adjacent dependency is `SciMLTesting`, which is test-only and whose compat (`2.1`) is unchanged by this diff.