### PR TITLE
Enable rendered API docs QA

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -20,6 +20,15 @@ run_qa(
             ),
         ),
     ),
+    api_docs_kwargs = (;
+        rendered = true,
+        rendered_ignore = (
+            :value,    # NLSolversBase reexport
+            :value!,   # NLSolversBase reexport
+            :value!!,  # NLSolversBase reexport
+            :f_calls,  # NLSolversBase reexport
+        ),
+    ),
 )
 
 # JET surfaces method/typo errors only on Julia >= 1.12 (the QA `1` lane), while the


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary
- Enable SciMLTesting rendered public API docs QA.
- Ignore NLSolversBase-owned reexports in rendered docs coverage instead of documenting dependency-owned symbols here.

## Validation
- `git diff --check`
- `Runic.main(["--check", "test/qa/qa.jl"])` on Julia 1.10
- `Runic.main(["--check", "src", "test", "docs/make.jl"])` on Julia 1.10
- `julia +1.10 --project=docs -e "using Pkg; Pkg.instantiate(); pushfirst!(LOAD_PATH, pwd()); include("docs/make.jl")"`
- `julia +1.10 --project=test/qa test/qa/qa.jl`
