### PR TITLE
Stabilize regression test initialization

### DIFF
--- a/test/regression.jl
+++ b/test/regression.jl
@@ -24,8 +24,8 @@ using StableRNGs
     @test sum(abs, inv(X'X + r * I) * X' * Y .- reshape(Evolutionary.minimizer(result), n, n2)) ≈ 0.001 atol = 1.0e-3
 
     # using matrix individual
-    res1 = Evolutionary.optimize(linear, randn(n, n2), CMAES(μ = 100, c_1 = 0.05), opts)
-    res2 = Evolutionary.optimize(ridge, randn(n, n2), CMAES(μ = 100, c_1 = 0.05), opts)
+    res1 = Evolutionary.optimize(linear, randn(rng, n, n2), CMAES(μ = 100, c_1 = 0.05), opts)
+    res2 = Evolutionary.optimize(ridge, randn(rng, n, n2), CMAES(μ = 100, c_1 = 0.05), opts)
     @test sum(abs, inv(X'X) * X' * Y .- Evolutionary.minimizer(res1)) ≈ 0.001 atol = 1.0e-3
     @test sum(abs, inv(X'X + r * I) * X' * Y .- Evolutionary.minimizer(res2)) ≈ 0.001 atol = 1.0e-3
 


### PR DESCRIPTION
## Summary
- use the existing `StableRNG(42)` for both matrix initial populations in `test/regression.jl`
- removes dependence on the process-global RNG that made the Julia 1.13 RC lane intermittent

## Evidence
- clean `master` RC1 CI failed at `test/regression.jl:30`
- clean local `master`: 1 failure in 17 natural RC1 runs; global seed 16 deterministically failed
- fixed change: 20/20 RC1 global-seed trials passed, including seed 16
- `Pkg.test()` passed on Julia 1.13.0-rc1 and Julia 1.12.6
- Runic check and `git diff --check` passed

Ignore until reviewed by @ChrisRackauckas.