### PR TITLE
Render Evolutionary objective API docs

### DIFF
--- a/docs/src/dev.md
+++ b/docs/src/dev.md
@@ -35,6 +35,18 @@ minimizer(::AbstractOptimizerState)
 terminate(::AbstractOptimizerState)
 ```
 
+### Reexported Objective API
+
+Evolutionary reexports the following NLSolversBase objective-access functions for use
+when implementing an optimizer state or evaluation strategy.
+
+```@docs
+NLSolversBase.value
+NLSolversBase.value!
+NLSolversBase.value!!
+NLSolversBase.f_calls
+```
+
 ### Population
 
 The evolutionary algorithms require a collection of individuals, **population**, which the algorithm constantly modifies. The population collection type must be derived from the `AbstractVector` type. Function `initial_population` is used for implementing a strategy of population collection initialization.

--- a/docs/src/dev.md
+++ b/docs/src/dev.md
@@ -37,14 +37,15 @@ terminate(::AbstractOptimizerState)
 
 ### Reexported Objective API
 
-Evolutionary reexports the following NLSolversBase objective-access functions for use
-when implementing an optimizer state or evaluation strategy.
+Evolutionary extends and reexports the following objective-access functions for use
+with `EvolutionaryObjective` values when implementing an optimizer state or evaluation
+strategy.
 
 ```@docs
-NLSolversBase.value
-NLSolversBase.value!
-NLSolversBase.value!!
-NLSolversBase.f_calls
+Evolutionary.value
+Evolutionary.value!
+Evolutionary.value!!
+Evolutionary.f_calls
 ```
 
 ### Population

--- a/src/api/objective.jl
+++ b/src/api/objective.jl
@@ -42,8 +42,43 @@ function EvolutionaryObjective(
     return EvolutionaryObjective{TC, TF, typeof(x), Val{eval}}(f, F, :(), 0)
 end
 
+"""
+    f_calls(obj::EvolutionaryObjective)
+
+Return the number of objective evaluations performed by `obj`.
+
+# Arguments
+- `obj`: Objective wrapper whose evaluation count is queried.
+
+# Examples
+```julia
+julia> obj = EvolutionaryObjective(sum, zeros(2));
+
+julia> value!(obj, [1.0, 2.0]); f_calls(obj)
+1
+```
+"""
 f_calls(obj::EvolutionaryObjective) = obj.f_calls
 
+"""
+    value(obj::EvolutionaryObjective)
+    value(obj::EvolutionaryObjective, x)
+
+Return the cached objective value of `obj`, or evaluate the objective at `x`.
+Evaluation increments [`f_calls`](@ref).
+
+# Arguments
+- `obj`: Objective wrapper to inspect or evaluate.
+- `x`: Candidate point supplied to the wrapped objective.
+
+# Examples
+```julia
+julia> obj = EvolutionaryObjective(sum, zeros(2));
+
+julia> value(obj, [1.0, 2.0])
+3.0
+```
+"""
 value(obj::EvolutionaryObjective) = obj.F
 
 """
@@ -58,11 +93,54 @@ function value(obj::EvolutionaryObjective{TC, TF, TX, TP}, x::TX) where {TC, TF,
     return obj.f(x)::TF
 end
 
+"""
+    value!(obj::EvolutionaryObjective, x)
+    value!(obj::EvolutionaryObjective, values, population)
+
+Evaluate an `EvolutionaryObjective`, store the result in its cache, and return the
+stored value. With `values` and `population`, evaluate each population member into
+the supplied output array.
+
+# Arguments
+- `obj`: Objective wrapper to evaluate.
+- `x`: Candidate point to evaluate.
+- `values`: Preallocated output array for population evaluation.
+- `population`: Candidate points to evaluate.
+
+# Examples
+```julia
+julia> obj = EvolutionaryObjective(sum, zeros(2));
+
+julia> value!(obj, [1.0, 2.0])
+3.0
+```
+"""
 function value!(obj::EvolutionaryObjective{TC, TF, TX, TP}, x::TX) where {TC, TF, TX, TP}
     obj.F = value(obj, x)
     return obj.F
 end
 
+"""
+    value!!(obj::EvolutionaryObjective, x)
+    value!!(obj::EvolutionaryObjective, values, x)
+
+Evaluate an `EvolutionaryObjective` after copying `x` into its cached input, then
+return the objective value. Use this variant when later optimizer steps need the
+evaluated candidate retained by the objective wrapper.
+
+# Arguments
+- `obj`: Objective wrapper to evaluate and update.
+- `x`: Candidate point to cache and evaluate.
+- `values`: Workspace used by an in-place objective evaluation.
+
+# Examples
+```julia
+julia> obj = EvolutionaryObjective(sum, zeros(2));
+
+julia> value!!(obj, [1.0, 2.0])
+3.0
+```
+"""
 function value!!(obj::EvolutionaryObjective{TC, TF, TX, TP}, x::TX) where {TC, TF, TX, TP}
     copyto!(obj.x_f, x)
     return value!(obj, x)

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -20,14 +20,6 @@ run_qa(
             ),
         ),
     ),
-    api_docs_kwargs = (;
-        rendered_ignore = (
-            :value,    # NLSolversBase reexport
-            :value!,   # NLSolversBase reexport
-            :value!!,  # NLSolversBase reexport
-            :f_calls,  # NLSolversBase reexport
-        ),
-    ),
 )
 
 # JET surfaces method/typo errors only on Julia >= 1.12 (the QA `1` lane), while the


### PR DESCRIPTION
## Summary
- render Evolutionary's intentional NLSolversBase objective-access reexports in the developer API documentation
- place SciMLStyle docstrings with usage examples on Evolutionary's own `EvolutionaryObjective` accessor methods
- remove the corresponding `rendered_ignore` QA exception
- this does not remove or change a documented interface; reexport removal is only non-breaking where the removed name was not documented

## Validation
- `GROUP=QA julia +1.12 --project=. -e 'using Pkg; Pkg.test()'`
- `julia +1.12 --project=docs docs/make.jl` against the local checkout
- Runic check
- `git diff --check`

Ignore until reviewed by @ChrisRackauckas.