### PR TITLE
docs: enable Evolutionary doctests

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,7 +2,6 @@ using Documenter, Evolutionary
 
 makedocs(
     modules = [Evolutionary],
-    doctest = false,
     clean = true,
     sitename = "Evolutionary.jl",
     pages = [


### PR DESCRIPTION
This focused PR removes the repository-specific `doctest = false` override from `docs/make.jl`. SciMLTesting >=2.4/2.10 already provides the strict QA defaults; no public API or QA allowlist changes are included.

Verification on current `master` (`59117e4`):
- `GROUP=QA julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`: `QA | 17 4 21`; the four broken cases are the existing documented Aqua/JET exceptions in `test/qa/qa.jl`.\n- `julia --startup-file=no --project=docs docs/make.jl`: passed; Documenter completed doctests, cross-references, checks, and HTML rendering.\n- `julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`: passed; all package test summaries completed, including `Regression | 3/3` and `Genetic Programming | 78/78`.\n- `julia --startup-file=no --project=. -m Runic --check docs/make.jl`: passed.\n- `typos docs/make.jl`: passed.\n- `git diff --check`: passed.\n\nI did not run optional downstream/GPU jobs. Please ignore this draft until reviewed by @ChrisRackauckas.